### PR TITLE
Fix require statement for webpack2 compatibility

### DIFF
--- a/lib/createContainer.js
+++ b/lib/createContainer.js
@@ -78,7 +78,7 @@ module.exports = function createContainer (options, __parentContainer) {
 
   // Partially applied to the loadModules function.
   const _loadModulesDeps = {
-    require: options.require || require,
+    require: options.require || function(uri) { return require(uri) },
     listModules: listModules,
     container: container
   }

--- a/lib/createContainer.js
+++ b/lib/createContainer.js
@@ -78,7 +78,7 @@ module.exports = function createContainer (options, __parentContainer) {
 
   // Partially applied to the loadModules function.
   const _loadModulesDeps = {
-    require: options.require || function(uri) { return require(uri) },
+    require: options.require || function (uri) { return require(uri) },
     listModules: listModules,
     container: container
   }


### PR DESCRIPTION
The current master branch fails to build on webpack2 due to the `options.require || require` statement on line 81.

I have wrapped `require` as a dynamic function so that it will build with webpack2.

In addition, I have created an issue on webpack's page for this, as I believe the blame ultimately rests on them. However, for the sake of compatibility, I've made this PR.