### PR TITLE
Stricter tsconfig. Fixed implicit return in TS typings.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,7 @@ export declare interface AwilixContainer {
   registerClass<T>(nameAndClassPair: RegisterNameAndClassPair<T>): AwilixContainer
   registerClass<T>(nameAndArrayClassPair: RegisterNameAndArrayClassPair<T>): AwilixContainer
   registerFunction(name: string, fn: Function): AwilixContainer
-  registerFunction(nameAndFunctionPair: RegisterNameAndFunctionPair)
+  registerFunction(nameAndFunctionPair: RegisterNameAndFunctionPair): AwilixContainer
   registerFunction(nameAndArrayPair: RegisterNameAndArrayFunctionPair): AwilixContainer
   registerValue(name: string, value: any): AwilixContainer
   registerValue(nameAndValuePairs: RegisterNameAndValuePair): AwilixContainer

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,11 @@
     "module": "commonjs",
     "outDir": "dist",
     "sourceMap": false,
-    "target": "es6"
+    "target": "es6",
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "noImplicitReturns": true,
+    "strictNullChecks": true
   },
   "include": [
     "test/**/*.ts"


### PR DESCRIPTION
I'm using stricter checks in my own project, and it fails to compile because of the missing return in one of the registerFunction declarations. I've added the stricter checks to the tsconfig.json so the test will fail if this happens again.