### PR TITLE
Guard assertions

### DIFF
--- a/lib/AwilixNotAFunctionError.js
+++ b/lib/AwilixNotAFunctionError.js
@@ -1,0 +1,22 @@
+const ExtendableError = require('./ExtendableError')
+
+/**
+ * Error thrown to indicate awilix was expecting a function (or class)
+ */
+class AwilixNotAFunctionError extends ExtendableError {
+  /**
+   * Constructor, takes the registered modules and unresolved tokens
+   * to create a message.
+   *
+   * @param {string} name
+   * The name of the module that could not be resolved.
+   *
+   * @param  {string[]} resolutionStack
+   * The current resolution stack
+   */
+  constructor (functionName, expectedType, givenType) {
+    super(`The function ${functionName} expected a ${expectedType}, ${givenType} given.`)
+  }
+}
+
+module.exports = AwilixNotAFunctionError

--- a/lib/registrations.js
+++ b/lib/registrations.js
@@ -1,5 +1,7 @@
 const Lifetime = require('./Lifetime')
 const ResolutionMode = require('./ResolutionMode')
+const isFunction = require('./isFunction')
+const AwilixNotAFunctionError = require('./AwilixNotAFunctionError')
 
 /**
  * Makes an options object based on defaults.
@@ -93,6 +95,10 @@ module.exports.asValue = asValue
  * The registration.
  */
 const asFunction = (fn, opts) => {
+  if (!isFunction(fn)) {
+    throw new AwilixNotAFunctionError('asFunction', 'function', typeof fn)
+  }
+
   const defaults = {
     lifetime: Lifetime.TRANSIENT
   }
@@ -128,6 +134,10 @@ module.exports.asFunction = asFunction
  * The registration.
  */
 const asClass = (Type, opts) => {
+  if (!isFunction(Type)) {
+    throw new AwilixNotAFunctionError('asClass', 'class', typeof Type)
+  }
+
   const defaults = {
     lifetime: Lifetime.TRANSIENT
   }

--- a/test/lib/isFunction.spec.js
+++ b/test/lib/isFunction.spec.js
@@ -4,6 +4,7 @@ describe('isFunction', function () {
   it('returns true when the value is a function', function () {
     isFunction(() => {}).should.be.true
     isFunction(function () {}).should.be.true
+    isFunction(class {}).should.be.true
   })
 
   it('returns false when the value is not a function', function () {

--- a/test/lib/registrations.spec.js
+++ b/test/lib/registrations.spec.js
@@ -2,6 +2,8 @@ const { asValue, asFunction, asClass } = require('../../lib/registrations')
 const createContainer = require('../../lib/createContainer')
 const Lifetime = require('../../lib/Lifetime')
 const ResolutionMode = require('../../lib/ResolutionMode')
+const AwilixNotAFunctionError = require('../../lib/AwilixNotAFunctionError')
+const { catchError } = require('../helpers/errorHelpers')
 
 const testFn = () => 1337
 const depsFn = (testClass) => testClass
@@ -74,6 +76,11 @@ describe('registrations', function () {
       result.testClass.should.be.an.instanceOf(TestClass)
       result.needsCradle.should.be.an.instanceOf(NeedsCradle)
     })
+
+    it('throws AwilixNotAFunctionError when given null', function () {
+      const err = catchError(() => asFunction(null))
+      err.should.be.an.instanceof(AwilixNotAFunctionError)
+    })
   })
 
   describe('asClass', function () {
@@ -117,6 +124,11 @@ describe('registrations', function () {
       result.should.be.an.instanceOf(MultipleDeps)
       result.testClass.should.be.an.instanceOf(TestClass)
       result.needsCradle.should.be.an.instanceOf(NeedsCradle)
+    })
+
+    it('throws an Error when given null', function () {
+      const err = catchError(() => asClass(null))
+      err.should.be.an.instanceof(AwilixNotAFunctionError)
     })
   })
 


### PR DESCRIPTION
Fixes issue #20 

In asClass/asFunction if isFunction is false for the first parameter, we throw an AwilixNotAFunctionError with a message like : "The function asClass expected a class, undefined given.", "The function asFunction expected a function, object given."...

Updated test for asClass, asFunction and isFunction