### PR TITLE
[TypeScript] container.loadModules returns container

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,7 @@
 export declare interface AwilixContainer {
   cradle: { [key: string]: any }
   createScope(): AwilixContainer
-  loadModules(globPatterns: string[] | Array<[string, RegistrationOptions]>, options?: LoadModulesOptions): ModuleDescriptor[]
+  loadModules(globPatterns: string[] | Array<[string, RegistrationOptions]>, options?: LoadModulesOptions): this
   registrations: Registration[]
   register(name: string, registration: Registration): this
   register(nameAndRegistrationPair: NameAndRegistrationPair): this


### PR DESCRIPTION
The current TypeScript definition for `container.loadModules` has a return value of ModuleDescriptor[], This is correct for lib/loadModules, but container.loadModules returns container instead.

This PR corrects that minor detail.