### PR TITLE
chore(travis): use cache directory to speed up CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: node_js
 node_js:
   - "stable"
 
+cache:
+  directories:
+    - node_modules
+
 # Lint errors should trigger a failure.
 before_script: npm run lint
 


### PR DESCRIPTION
This will speed up Travis builds by caching `node_modules`.