### PR TITLE
Support iterating registrations using cradle

### DIFF
--- a/lib/createContainer.js
+++ b/lib/createContainer.js
@@ -338,7 +338,12 @@ module.exports = function createContainer(options, __parentContainer) {
 
         // Another safe-guard against curious console logging.
         if (name === Symbol.iterator) {
-          return function*() {}
+          return function*() {
+            const registrations = rollUpRegistrations()
+            for (const registration in registrations) {
+              yield registration
+            }
+          }
         }
 
         throw new AwilixResolutionError(name, resolutionStack)

--- a/test/lib/createContainer.spec.js
+++ b/test/lib/createContainer.spec.js
@@ -539,6 +539,35 @@ describe('createContainer', function() {
       })
     })
 
+    describe('using util.inspect on the cradle', function() {
+      it('should return a summary', function() {
+        const container = createContainer()
+          .registerValue({ val1: 1, val2: 2 })
+          .registerFunction({ fn1: () => true })
+          .registerClass({ c1: Repo })
+
+        expect(util.inspect(container.cradle)).to.equal(
+          '[AwilixContainer.cradle]'
+        )
+      })
+    })
+
+    describe('using Array.from on the cradle', function() {
+      it('should return an Array with registration names', function() {
+        const container = createContainer()
+          .registerValue({ val1: 1, val2: 2 })
+          .registerFunction({ fn1: () => true })
+          .registerClass({ c1: Repo })
+
+        expect(Array.from(container.cradle)).to.deep.equal([
+          'val1',
+          'val2',
+          'fn1',
+          'c1'
+        ])
+      })
+    })
+
     describe('explicitly trying to fuck shit up', function() {
       it('should prevent you from fucking shit up', function() {
         const container = createContainer({
@@ -603,8 +632,8 @@ describe('createContainer', function() {
 
   describe('spreading the cradle', () => {
     it('does not throw', () => {
-      const container = createContainer()
-      expect([...container.cradle])
+      const container = createContainer().registerValue({ val1: 1, val2: 2 })
+      expect([...container.cradle]).to.deep.equal(['val1', 'val2'])
     })
   })
 })


### PR DESCRIPTION
In this PR:
* cradle[Symbol.iterator] returns a generator that iterates registration names
* add a test for cradle[Symbol.iterator] (by using Array.from)
* add a test for using util.inspect on the cradle
* modify test for spreading cradle into an array

This can help in cases where it's needed to look on the registrations in a cradle without resolving them, when there is no access to the `container` that it came from.