### PR TITLE
updated readme file to include resolverOptions for single module in container.loadModules

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,14 @@ const container = awilix.createContainer()
 // Load our modules!
 container.loadModules([
   // Globs!
+  [
+    // to have different resolverOptions against single module.
+    'models/**/*.js',
+    {
+      register: awilix.asValue,
+      lifetime: Lifetime.SINGLETON
+    }
+  ],
   'services/**/*.js',
   'repositories/**/*.js'
 ], {

--- a/README.md
+++ b/README.md
@@ -474,7 +474,7 @@ const container = awilix.createContainer()
 container.loadModules([
   // Globs!
   [
-    // to have different resolverOptions against single module.
+    // To have different resolverOptions for specific modules.
     'models/**/*.js',
     {
       register: awilix.asValue,


### PR DESCRIPTION
After the going through the discussion at [Cyclic dependencies detected](https://github.com/jeffijoe/awilix/issues/94), I believe its good to update the readme file of this package. So that its easy to find that we can have `resolverOptions` per module as well in a single `container.loadModules`

From
```
container.loadModules([
  // Globs
  'services/**/*.js',
  'repositories/**/*.js'
], {
  // We want to register `UserService` as `userService` -
  // by default loaded modules are registered with the
  // name of the file (minus the extension)
  formatName: 'camelCase',
  // Apply resolver options to all modules.
  resolverOptions: {
    // We can give these auto-loaded modules
    // the deal of a lifetime! (see what I did there?)
    // By default it's `TRANSIENT`.
    lifetime: Lifetime.SINGLETON,
    // We can tell Awilix what to register everything as,
    // instead of guessing. If omitted, will inspect the
    // module to determinw what to register as.
    register: awilix.asClass
  }
)

```

To
```
container.loadModules([
  // Globs!
  [
    // To have different resolverOptions for specific modules.
    'models/**/*.js',
    {
      register: awilix.asValue,
      lifetime: Lifetime.SINGLETON
    }
  ],
  'services/**/*.js',
  'repositories/**/*.js'
], {
  // We want to register `UserService` as `userService` -
  // by default loaded modules are registered with the
  // name of the file (minus the extension)
  formatName: 'camelCase',
  // Apply resolver options to all modules.
  resolverOptions: {
    // We can give these auto-loaded modules
    // the deal of a lifetime! (see what I did there?)
    // By default it's `TRANSIENT`.
    lifetime: Lifetime.SINGLETON,
    // We can tell Awilix what to register everything as,
    // instead of guessing. If omitted, will inspect the
    // module to determinw what to register as.
    register: awilix.asClass
  }
)
```