### PR TITLE
Makes promise-friendly handling interactions with "then" property

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,18 @@
-dist
+# Dependencies and Node-related
 node_modules
 npm-debug.log
-coverage
-.DS_Store
-.vscode/
 examples/babel/package-lock.json
+
+# Code Coverage
+coverage
+
+# Build
+dist
 lib
+
+# IDE
+.vscode/
+.idea/
+
+# System
+.DS_Store

--- a/src/__tests__/container.test.ts
+++ b/src/__tests__/container.test.ts
@@ -409,6 +409,19 @@ describe('container', function() {
       expect(err.message).toContain('first -> second')
       expect(err.message).toContain('lol')
     })
+
+    it('behaves properly when the cradle is returned from an async function', async function() {
+      const container = createContainer()
+      container.register({ value: asValue(42) })
+
+      async function example() {
+        return container.cradle
+      }
+
+      const { value } = await example()
+
+      expect(value).toBe(42)
+    })
   })
 
   describe('loadModules', function() {

--- a/src/container.ts
+++ b/src/container.ts
@@ -359,10 +359,12 @@ export function createContainer(
   function register(arg1: any, arg2: any): AwilixContainer {
     const obj = nameValueToObject(arg1, arg2)
     const keys = [...Object.keys(obj), ...Object.getOwnPropertySymbols(obj)]
+
     for (const key of keys) {
       const value = obj[key as any] as Resolver<any>
       registrations[key as any] = value
     }
+
     // Invalidates the computed registrations.
     computedRegistrations = null
     return container
@@ -416,6 +418,12 @@ export function createContainer(
         // throw an error (issue #7).
         if (name === util.inspect.custom || name === 'inspect') {
           return inspectCradle
+        }
+
+        // Edge case: Promise unwrapping will look for a "then" property and attempt to call it.
+        // Return undefined so that we won't cause a resolution error. (issue #109)
+        if (name === 'then') {
+          return undefined
         }
 
         // When using `Array.from` or spreading the cradle, this will


### PR DESCRIPTION
This handles the case related to #109 to allow for friendly usage in async contexts.

@jeffijoe — I've maintained 100% coverage. Are there any specific tests you were looking for me to add?