### PR TITLE
Adding note to run a build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1282,7 +1282,7 @@ because they depend on Node-specific packages.
 
 # Contributing
 
-Clone repo, run `npm i` to install all dependencies, and then
+Clone repo, run `npm i` to install all dependencies, run `npm run build` to create an initial build, and then
 `npm run test -- --watchAll` to start writing code.
 
 For code coverage, run `npm run cover`.


### PR DESCRIPTION
If you skip this step, you'll get an error during testing:

```
Cannot find module '../../lib/awilix' from 'rollup.test.ts'
```