### PR TITLE
feat: allow autoloading of non-default exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,11 @@ boring. You can automate this by using `loadModules`.
 > }
 > ```
 
+Note that **multiple** services can be registered per file, i.e. it is
+possible to have a file with a default export and named exports and for
+all of them to be loaded. The named exports do require the `RESOLVER`
+token to be recognized.
+
 Imagine this app structure:
 
 * `app`

--- a/README.md
+++ b/README.md
@@ -451,6 +451,24 @@ boring. You can automate this by using `loadModules`.
 > * `module.exports = ...`
 > * `module.exports.default = ...`
 > * `export default ...`
+> 
+> To load a non-default export, set the `[RESOLVER]` property on it:
+> 
+> ```js
+> const { RESOLVER } = require('awilix');
+> export class ServiceClass {
+> }
+> ServiceClass[RESOLVER] = {}
+> ```
+>
+> Or even more concise using TypeScript:
+> ```typescript
+> // TypeScript
+> import { RESOLVER } from 'awilix'
+> export class ServiceClass {
+>   static [RESOLVER] = {}
+> }
+> ```
 
 Imagine this app structure:
 

--- a/src/__tests__/load-modules.test.ts
+++ b/src/__tests__/load-modules.test.ts
@@ -15,12 +15,17 @@ describe('loadModules', function() {
     const container = createContainer()
 
     class SomeClass {}
+    class SomeNonDefaultClass {
+      static [RESOLVER] = {}
+    }
 
     const modules: any = {
       'nope.js': undefined,
       'standard.js': jest.fn(() => 42),
       'default.js': { default: jest.fn(() => 1337) },
-      'someClass.js': SomeClass
+      'someClass.js': SomeClass,
+      'someNonDefaultClass.js': { SomeNonDefaultClass },
+      'nopeClass.js': { SomeClass }
     }
     const moduleLookupResult = lookupResultFor(modules)
     const deps = {
@@ -31,10 +36,13 @@ describe('loadModules', function() {
 
     const result = loadModules(deps, 'anything')
     expect(result).toEqual({ loadedModules: moduleLookupResult })
-    expect(Object.keys(container.registrations).length).toBe(3)
+    expect(Object.keys(container.registrations).length).toBe(4)
     expect(container.resolve('standard')).toBe(42)
     expect(container.resolve('default')).toBe(1337)
     expect(container.resolve('someClass')).toBeInstanceOf(SomeClass)
+    expect(container.resolve('someNonDefaultClass')).toBeInstanceOf(
+      SomeNonDefaultClass
+    )
   })
 
   it('uses built-in formatter when given a formatName as a string', function() {

--- a/src/load-modules.ts
+++ b/src/load-modules.ts
@@ -97,26 +97,37 @@ export function loadModules(
       return undefined
     }
 
-    if (!isFunction(loaded)) {
-      if (loaded.default && isFunction(loaded.default)) {
-        // ES6 default export
+    if (isFunction(loaded)) {
+      return {
+        name: m.name,
+        path: m.path,
+        value: loaded,
+        opts: m.opts
+      }
+    }
+
+    if (loaded.default && isFunction(loaded.default)) {
+      // ES6 default export
+      return {
+        name: m.name,
+        path: m.path,
+        value: loaded.default,
+        opts: m.opts
+      }
+    }
+
+    for (const key of Object.keys(loaded)) {
+      if (isFunction(loaded[key]) && RESOLVER in loaded[key]) {
         return {
           name: m.name,
           path: m.path,
-          value: loaded.default,
+          value: loaded[key],
           opts: m.opts
         }
       }
-
-      return undefined
     }
 
-    return {
-      name: m.name,
-      path: m.path,
-      value: loaded,
-      opts: m.opts
-    }
+    return undefined
   })
   result.filter(x => x).forEach(registerDescriptor.bind(null, container, opts))
   return {

--- a/src/load-modules.ts
+++ b/src/load-modules.ts
@@ -98,6 +98,7 @@ export function loadModules(
     }
 
     if (isFunction(loaded)) {
+      // for module.exports = ...
       return {
         name: m.name,
         path: m.path,
@@ -116,6 +117,8 @@ export function loadModules(
       }
     }
 
+    // no export found so far - loop through non-default exports, but require the RESOLVER property set for
+    // it to be a valid service module export.
     for (const key of Object.keys(loaded)) {
       if (isFunction(loaded[key]) && RESOLVER in loaded[key]) {
         return {


### PR DESCRIPTION
Module default exports are discouraged in e.g. [`tslint`](https://palantir.github.io/tslint/rules/no-default-export/); the `no-default-export` setting is set to true when using out-of-the-box settings for the quite popular [`gts`](https://www.npmjs.com/package/gts) styles.

This proposed PR allows for a non-default export to be loaded if it contains a static property with the `RESOLVER` key, even if that property is just an empty object. The dropped default export requirement would allow for better compliance with these `tslint` best practices.

Because the default export is tried first and non-default exports must have the `RESOLVER` key, the change should be fully backward-compatible.

Tests have been amended to cover this case. Suggestions are welcome!