### PR TITLE
fix(examples/simple): don't rely on relative paths

### DIFF
--- a/examples/simple/index.js
+++ b/examples/simple/index.js
@@ -10,7 +10,8 @@ container.register('database', awilix.asValue('stuffs_db'))
 // Auto-load our services and our repositories.
 const opts = {
   // We want ClassicalService to be registered as classicalService.
-  formatName: 'camelCase'
+  formatName: 'camelCase',
+  cwd: __dirname
 }
 container.loadModules(
   [


### PR DESCRIPTION
cool project!

i was trying to run the example from the `awilix/` dir and kept getting mysterious resolution errors:

```
/.../awilix/lib/container.js:335
            throw err;
            ^

Error: Could not resolve 'classicalService'.

Resolution path: classicalService
```