### PR TITLE
JSON.stringify() container cradle results in memory leak because of cyclic references

### DIFF
--- a/src/__tests__/container.test.ts
+++ b/src/__tests__/container.test.ts
@@ -751,13 +751,13 @@ describe('memoizing registrations', () => {
   })
 
   describe('Safely stringify cradle', function() {
-    it('should have toJSON() return [AWILIX CONTAINER]', () => {
-      expect(createContainer().cradle.toJSON()).toBe('[AWILIX CONTAINER]')
+    it('should have toJSON() return [AwilixContainer.cradle]', () => {
+      expect(createContainer().cradle.toJSON()).toBe('[AwilixContainer.cradle]')
     })
 
-    it('JSON.stringify() should return [AWILIX CONTAINER]', () => {
+    it('JSON.stringify() should return [AwilixContainer.cradle]', () => {
       expect(JSON.stringify(createContainer().cradle)).toBe(
-        '"[AWILIX CONTAINER]"'
+        '"[AwilixContainer.cradle]"'
       )
     })
   })

--- a/src/__tests__/container.test.ts
+++ b/src/__tests__/container.test.ts
@@ -749,4 +749,16 @@ describe('memoizing registrations', () => {
       expect(otherContainer.build(fn)).toBe(1337)
     })
   })
+
+  describe('Safely stringify cradle', function() {
+    it('should have toJSON() return [AWILIX CONTAINER]', () => {
+      expect(createContainer().cradle.toJSON()).toBe('[AWILIX CONTAINER]')
+    })
+
+    it('JSON.stringify() should return [AWILIX CONTAINER]', () => {
+      expect(JSON.stringify(createContainer().cradle)).toBe(
+        '"[AWILIX CONTAINER]"'
+      )
+    })
+  })
 })

--- a/src/container.ts
+++ b/src/container.ts
@@ -239,12 +239,6 @@ export function createContainer(
        * Whatever the resolve call returns.
        */
       get: (target, name) => {
-        if (name === 'toJSON') {
-          return () => {
-            return '[AWILIX CONTAINER]'
-          }
-        }
-
         return resolve(name as string)
       },
 
@@ -425,6 +419,11 @@ export function createContainer(
           resolutionStack,
           'Cyclic dependencies detected.'
         )
+      }
+
+      // Used in JSON.stringify.
+      if (name === 'toJSON') {
+        return inspectCradle
       }
 
       // Used in console.log.

--- a/src/container.ts
+++ b/src/container.ts
@@ -238,7 +238,15 @@ export function createContainer(
        * @return {*}
        * Whatever the resolve call returns.
        */
-      get: (target, name) => resolve(name as string),
+      get: (target, name) => {
+        if (name === 'toJSON') {
+          return () => {
+            return '[AWILIX CONTAINER]'
+          }
+        }
+
+        return resolve(name as string)
+      },
 
       /**
        * Setting things on the cradle throws an error.

--- a/src/container.ts
+++ b/src/container.ts
@@ -238,9 +238,7 @@ export function createContainer(
        * @return {*}
        * Whatever the resolve call returns.
        */
-      get: (target, name) => {
-        return resolve(name as string)
-      },
+      get: (target, name) => resolve(name as string),
 
       /**
        * Setting things on the cradle throws an error.


### PR DESCRIPTION
Winston, sentry, and many more libraries, which call internally `JSON.stringify` or some other (custom) function for JSON serialization, cause a memory leak when passed a container cradle.

I especially had the case together with Sequelize and winston json formatter. For some reason, sometimes (mostly in case of errors) it tried to log the whole container cradle. This took forever and resulted in a silent app crash which was not immediately traced back to the problems roots.

This PR simply checks if the container cradle was called via `JSON.stringify` by checking for `toJSON` and returns a simple string.

Following github issues are connected to this:
https://github.com/coopernurse/node-pool/issues/275
https://github.com/sequelize/sequelize/issues/10443

Thanks!