### PR TITLE
Fixes AwilixResolutionError throwing TypeError if resolution stack contains symbols.

### DIFF
--- a/src/__tests__/container.test.ts
+++ b/src/__tests__/container.test.ts
@@ -152,6 +152,16 @@ describe('container', function () {
       expect(err.message).toMatch(/i am the derg/i)
     })
 
+    it('throws an AwilixResolutionError that supports symbols on multiple levels', function () {
+      const container = createContainer()
+      const S1 = Symbol('i am the derg')
+      const S2 = Symbol('i am not the derg')
+      container.register({ [S2]: asFunction(({ [S1]: theDerg }) => theDerg) })
+      const err = throws(() => container.resolve(S2))
+      expect(err).toBeInstanceOf(AwilixResolutionError)
+      expect(err.message).toMatch(/i am the derg/i)
+    })
+
     it('throws an AwilixResolutionError with a resolution path when resolving an unregistered dependency', function () {
       const container = createContainer()
       container.register({

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -130,9 +130,9 @@ export class AwilixResolutionError extends AwilixError {
     if (typeof name === 'symbol') {
       name = (name as any).toString()
     }
-    resolutionStack = resolutionStack
-      .slice()
-      .map((val) => (typeof val === 'symbol' ? (val as any).toString() : val))
+    resolutionStack = resolutionStack.map((val) =>
+      typeof val === 'symbol' ? (val as any).toString() : val
+    )
     resolutionStack.push(name)
     const resolutionPathString = resolutionStack.join(' -> ')
     let msg = `Could not resolve '${name as any}'.`

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -130,7 +130,9 @@ export class AwilixResolutionError extends AwilixError {
     if (typeof name === 'symbol') {
       name = (name as any).toString()
     }
-    resolutionStack = resolutionStack.slice()
+    resolutionStack = resolutionStack
+      .slice()
+      .map((val) => (typeof val === 'symbol' ? (val as any).toString() : val))
     resolutionStack.push(name)
     const resolutionPathString = resolutionStack.join(' -> ')
     let msg = `Could not resolve '${name as any}'.`


### PR DESCRIPTION
I use symbols heavily in resolution so they may exist on multiple levels. I found the AwilixResolutionError was throwing another error: "TypeError: Cannot convert a Symbol value to a string". The symbol "names" in the resolution stack were failing on the array join. I added a test to cover this scenario.

Code coverage: 100%
Linting Passes

Please let me know if there is anything else you would like me to do.