### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ written in [TypeScript](http://typescriptlang.org). **Make IoC great again!**
 Install with `npm`
 
 ```
-npm install awilix --save
+npm install awilix
 ```
 
 Or `yarn`


### PR DESCRIPTION
As of npm 5.0.0, installed modules are added as a dependency by default, so the --save option is no longer needed.