### PR TITLE
trying to fix #225 with pathToFileURL (breaks tests)

### DIFF
--- a/src/load-modules.ts
+++ b/src/load-modules.ts
@@ -135,9 +135,11 @@ async function loadEsModules<ESM extends boolean>(
   opts: LoadModulesOptions<ESM>
 ): Promise<LoadModulesResult> {
   const importPromises = []
+  const isWindows = process.platform === 'win32';
   for (const m of modules) {
     //importPromises.push(dependencies.require(m.path))
-    importPromises.push(dependencies.require(pathToFileURL(m.path).toString()))
+    const _path = isWindows? pathToFileURL(m.path).toString(): m.path;
+    importPromises.push(dependencies.require(_path))
   }
   const imports = await Promise.all(importPromises)
   const result = []

--- a/src/load-modules.ts
+++ b/src/load-modules.ts
@@ -15,6 +15,7 @@ import { AwilixContainer } from './container'
 import { isClass, isFunction } from './utils'
 import { BuildResolver } from './awilix'
 import { camelCase } from 'camel-case'
+import { pathToFileURL } from 'url';
 
 /**
  * The options when invoking loadModules().
@@ -135,7 +136,8 @@ async function loadEsModules<ESM extends boolean>(
 ): Promise<LoadModulesResult> {
   const importPromises = []
   for (const m of modules) {
-    importPromises.push(dependencies.require(m.path))
+    //importPromises.push(dependencies.require(m.path))
+    importPromises.push(dependencies.require(pathToFileURL(m.path).toString()))
   }
   const imports = await Promise.all(importPromises)
   const result = []


### PR DESCRIPTION
this change breaks test, only for consultation

  ● loadModules › registers loaded modules async when using native modules

    expect(received).toBe(expected) // Object.is equality

    Expected: 3
    Received: 0

      60 |     const result = await loadModules(deps, 'anything', { esModules: true })
      61 |     expect(result).toEqual({ loadedModules: moduleLookupResult })
    > 62 |     expect(Object.keys(container.registrations).length).toBe(3)