### PR TITLE
Improve resolve typing

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -80,6 +80,19 @@ export interface AwilixContainer<Cradle extends object = any> {
    * @return {*}
    * Whatever was resolved.
    */
+  resolve<K extends keyof Cradle>(
+    name: K,
+    resolveOptions?: ResolveOptions
+  ): Cradle[K]
+  /**
+   * Resolves the registration with the given name.
+   *
+   * @param  {string} name
+   * The name of the registration to resolve.
+   *
+   * @return {*}
+   * Whatever was resolved.
+   */
   resolve<T>(name: string | symbol, resolveOptions?: ResolveOptions): T
   /**
    * Checks if the registration with the given name exists.


### PR DESCRIPTION
Would allow calls like this

```
interface CradleType {
  readonly someServiceKey: SomeService;
}

const container = createContainer<ContainerType>();
container.register({
  someServiceKey: asFunction(createSomeService)
});

// still allows
container.register('someValue', asValue('stringValue'));

// this is the benefit
const someService = container.resolve('someServiceKey');
// above will be typed as 'SomeService' (because of new added declaration)
// also will help with code completing of used string

// dont need:
// const someService = container.resolve<SomeService>('someServiceKey'); // no type checking of used string (whether it matches a key in CradleType)
// or
// const someService = container.resolve('someServiceKey') as SomeService; // explicit cast

// also still allowed (will match the previously existing declaration of 'resolve()')
const value = container.resolve('someValue'); // will be typed as 'unknown'
```