### PR TITLE
Array.isArray is preferred over instanceof

### DIFF
--- a/src/list-modules.ts
+++ b/src/list-modules.ts
@@ -61,7 +61,7 @@ function _listModules(
 ): Array<ModuleDescriptor> {
   opts = { cwd: process.cwd(), glob: glob.sync, ...opts }
   let patternOpts: ResolverOptions<any> | null = null
-  if (globPattern instanceof Array) {
+  if (Array.isArray(globPattern)) {
     patternOpts = globPattern[1] as ResolverOptions<any>
     globPattern = globPattern[0]
   }


### PR DESCRIPTION
Hi Jeff, one small update on this one.
In this file there are 2 checks to verify if it is an array. First uses `Array.isArray` and the other `instanceof` 
Looks like the Array.isArray is preferred over instanceof:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray#instanceof_vs_isarray