### PR TITLE
Adding a few missing boolean return types.

### DIFF
--- a/src/function-tokenizer.ts
+++ b/src/function-tokenizer.ts
@@ -261,7 +261,7 @@ export function createTokenizer(source: string) {
  * Determines if the given character is a whitespace character.
  *
  * @param  {string}  ch
- * @return {Boolean}
+ * @return {boolean}
  */
 function isWhiteSpace(ch: string): boolean {
   switch (ch) {
@@ -276,7 +276,7 @@ function isWhiteSpace(ch: string): boolean {
 /**
  * Determines if the specified character is a string quote.
  * @param  {string}  ch
- * @return {Boolean}
+ * @return {boolean}
  */
 function isStringQuote(ch: string): boolean {
   switch (ch) {

--- a/src/injection-mode.ts
+++ b/src/injection-mode.ts
@@ -13,6 +13,7 @@ export const InjectionMode: Record<InjectionModeType, InjectionModeType> = {
    * @type {String}
    */
   PROXY: 'PROXY',
+
   /**
    * The dependencies will be resolved by inspecting parameter names of the function/constructor.
    *

--- a/src/param-parser.ts
+++ b/src/param-parser.ts
@@ -116,8 +116,9 @@ export function parseParameterList(source: string): Array<Parameter> {
 
   /**
    * Determines if the current token represents a constructor, and the next token after it is a paren
+   * @return {boolean}
    */
-  function isConstructorToken() {
+  function isConstructorToken(): boolean {
     return t.type === 'ident' && t.value === 'constructor'
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -61,9 +61,9 @@ export function last<T>(arr: Array<T>): T {
  * Determines if the given function is a class.
  *
  * @param  {Function} fn
- * @return {Boolean}
+ * @return {boolean}
  */
-export function isClass(fn: Function | Constructor<any>) {
+export function isClass(fn: Function | Constructor<any>): boolean {
   /*tslint:disable-next-line*/
   if (typeof fn !== 'function') {
     return false
@@ -92,10 +92,10 @@ export function isClass(fn: Function | Constructor<any>) {
  * @param  {Any} val
  * Any value to check if it's a function.
  *
- * @return {Boolean}
+ * @return {boolean}
  * true if the value is a function, false otherwise.
  */
-export function isFunction(val: any) {
+export function isFunction(val: any): boolean {
   return typeof val === 'function'
 }
 


### PR DESCRIPTION
- Adding a few missing return boolean types
- lower case boolean type based on this "[It is recommended to use the primitive type boolean](https://www.tutorialsteacher.com/typescript/typescript-boolean)"
- Adding an empty line on **injection-mode.ts** just to keep consistency with **lifetime.ts**