### PR TITLE
Update tests to use arrow functions when possible.

### DIFF
--- a/src/__tests__/awilix.test.ts
+++ b/src/__tests__/awilix.test.ts
@@ -4,27 +4,27 @@ import { listModules } from '../list-modules'
 import { AwilixResolutionError } from '../errors'
 import { asValue, asClass, asFunction, aliasTo } from '../resolvers'
 
-describe('awilix', function () {
-  it('exists', function () {
+describe('awilix', () => {
+  it('exists', () => {
     expect(awilix).toBeDefined()
   })
 
-  it('has a createContainer function', function () {
+  it('has a createContainer function', () => {
     expect(awilix).toHaveProperty('createContainer')
     expect(awilix.createContainer).toBe(createContainer)
   })
 
-  it('has a listModules function', function () {
+  it('has a listModules function', () => {
     expect(awilix).toHaveProperty('listModules')
     expect(awilix.listModules).toBe(listModules)
   })
 
-  it('has an AwilixResolutionError function', function () {
+  it('has an AwilixResolutionError function', () => {
     expect(awilix).toHaveProperty('AwilixResolutionError')
     expect(awilix.AwilixResolutionError).toBe(AwilixResolutionError)
   })
 
-  it('has the asValue, asClass, asFunction and aliasTo functions', function () {
+  it('has the asValue, asClass, asFunction and aliasTo functions', () => {
     expect(awilix.asValue).toBe(asValue)
     expect(awilix.asClass).toBe(asClass)
     expect(awilix.asFunction).toBe(asFunction)

--- a/src/__tests__/container.test.ts
+++ b/src/__tests__/container.test.ts
@@ -30,15 +30,15 @@ class ManualTest {
   }
 }
 
-describe('createContainer', function () {
-  it('returns an object', function () {
+describe('createContainer', () => {
+  it('returns an object', () => {
     const container = createContainer()
     expect(typeof container).toBe('object')
   })
 })
 
-describe('container', function () {
-  it('lets me register something and resolve it', function () {
+describe('container', () => {
+  it('lets me register something and resolve it', () => {
     const container = createContainer()
     container.register({ someValue: asValue(42) })
     container.register({
@@ -54,7 +54,7 @@ describe('container', function () {
     expect(test.someValue).toBe(42)
   })
 
-  it('lets me register something and resolve it via classic injection mode', function () {
+  it('lets me register something and resolve it via classic injection mode', () => {
     const container = createContainer({
       injectionMode: InjectionMode.CLASSIC,
     })
@@ -68,8 +68,8 @@ describe('container', function () {
     expect(test.repo).toBeTruthy()
   })
 
-  describe('register', function () {
-    it('supports multiple registrations in a single call', function () {
+  describe('register', () => {
+    it('supports multiple registrations in a single call', () => {
       const container = createContainer()
       container.register({
         universe: asValue(42),
@@ -92,7 +92,7 @@ describe('container', function () {
       )
     })
 
-    it('supports classes', function () {
+    it('supports classes', () => {
       const container = createContainer()
       container.register({
         test: asClass(Test),
@@ -103,21 +103,21 @@ describe('container', function () {
     })
   })
 
-  describe('has', function () {
-    it('returns true if the registration does exist', function () {
+  describe('has', () => {
+    it('returns true if the registration does exist', () => {
       const container = createContainer()
       container.register({ theValue: asValue('theValue') })
 
       expect(container.has('theValue')).toBe(true)
     })
 
-    it('returns false if the registration does not exist', function () {
+    it('returns false if the registration does not exist', () => {
       expect(createContainer().has('theValue')).toBe(false)
     })
   })
 
-  describe('resolve', function () {
-    it('resolves the dependency graph and supports all resolvers', function () {
+  describe('resolve', () => {
+    it('resolves the dependency graph and supports all resolvers', () => {
       class TestClass {
         factoryResult: any
         constructor({ factory }: any) {
@@ -137,14 +137,14 @@ describe('container', function () {
       expect(root.factoryResult).toBe('factory 42')
     })
 
-    it('throws an AwilixResolutionError when there are unregistered dependencies', function () {
+    it('throws an AwilixResolutionError when there are unregistered dependencies', () => {
       const container = createContainer()
       const err = throws(() => container.resolve('nope'))
       expect(err).toBeInstanceOf(AwilixResolutionError)
       expect(err.message).toMatch(/nope/i)
     })
 
-    it('throws an AwilixResolutionError that supports symbols', function () {
+    it('throws an AwilixResolutionError that supports symbols', () => {
       const container = createContainer()
       const S = Symbol('i am the derg')
       const err = throws(() => container.resolve(S))
@@ -152,7 +152,7 @@ describe('container', function () {
       expect(err.message).toMatch(/i am the derg/i)
     })
 
-    it('throws an AwilixResolutionError that supports symbols on multiple levels', function () {
+    it('throws an AwilixResolutionError that supports symbols on multiple levels', () => {
       const container = createContainer()
       const S1 = Symbol('i am the derg')
       const S2 = Symbol('i am not the derg')
@@ -162,7 +162,7 @@ describe('container', function () {
       expect(err.message).toMatch(/i am the derg/i)
     })
 
-    it('throws an AwilixResolutionError with a resolution path when resolving an unregistered dependency', function () {
+    it('throws an AwilixResolutionError with a resolution path when resolving an unregistered dependency', () => {
       const container = createContainer()
       container.register({
         first: asFunction((cradle: any) => cradle.second),
@@ -174,7 +174,7 @@ describe('container', function () {
       expect(err.message).toContain('first -> second -> third')
     })
 
-    it('does not screw up the resolution stack when called twice', function () {
+    it('does not screw up the resolution stack when called twice', () => {
       const container = createContainer()
       container.register({
         first: asFunction((cradle: any) => cradle.second),
@@ -189,7 +189,7 @@ describe('container', function () {
       expect(err2.message).toContain('otherFirst -> second -> third')
     })
 
-    it('supports transient lifetime', function () {
+    it('supports transient lifetime', () => {
       const container = createContainer()
       let counter = 1
       container.register({
@@ -200,7 +200,7 @@ describe('container', function () {
       expect(container.cradle.hehe).toBe(2)
     })
 
-    it('supports singleton lifetime', function () {
+    it('supports singleton lifetime', () => {
       const container = createContainer()
       let counter = 1
       container.register({
@@ -211,7 +211,7 @@ describe('container', function () {
       expect(container.cradle.hehe).toBe(1)
     })
 
-    it('supports scoped lifetime', function () {
+    it('supports scoped lifetime', () => {
       const container = createContainer()
       let scopedCounter = 1
       container.register({
@@ -227,7 +227,7 @@ describe('container', function () {
       expect(scope2.cradle.scoped).toBe(2)
     })
 
-    it('caches singletons regardless of scope', function () {
+    it('caches singletons regardless of scope', () => {
       const container = createContainer()
       let singletonCounter = 1
       container.register({
@@ -243,7 +243,7 @@ describe('container', function () {
       expect(scope2.cradle.singleton).toBe(1)
     })
 
-    it('resolves transients regardless of scope', function () {
+    it('resolves transients regardless of scope', () => {
       const container = createContainer()
       let transientCounter = 1
       container.register({
@@ -259,7 +259,7 @@ describe('container', function () {
       expect(scope2.cradle.transient).toBe(4)
     })
 
-    it('does not use parents cache when scoped', function () {
+    it('does not use parents cache when scoped', () => {
       const container = createContainer()
       let scopedCounter = 1
       container.register({
@@ -300,7 +300,7 @@ describe('container', function () {
       expect(scope1Child.cradle.counterValue === 3).toBe(true)
     })
 
-    it('supports nested scopes', function () {
+    it('supports nested scopes', () => {
       const container = createContainer()
 
       // Increments the counter every time it is resolved.
@@ -320,7 +320,7 @@ describe('container', function () {
       expect(scope1Child.cradle.counterValue).toBe(3)
     })
 
-    it('resolves dependencies in scope', function () {
+    it('resolves dependencies in scope', () => {
       const container = createContainer()
       // Register a transient function
       // that returns the value of the scope-provided dependency.
@@ -338,7 +338,7 @@ describe('container', function () {
       expect(scope.cradle.scopedValue).toBe('Hello scope')
     })
 
-    it('cannot find a scope-registered value when resolved from root', function () {
+    it('cannot find a scope-registered value when resolved from root', () => {
       const container = createContainer()
       // Register a transient function
       // that returns the value of the scope-provided dependency.
@@ -358,7 +358,7 @@ describe('container', function () {
       )
     })
 
-    it('supports overwriting values in a scope', function () {
+    it('supports overwriting values in a scope', () => {
       const container = createContainer()
       // It does not matter when the scope is created,
       // it will still have anything that is registered
@@ -411,7 +411,7 @@ describe('container', function () {
       )
     })
 
-    it('throws an AwilixResolutionError when there are cyclic dependencies', function () {
+    it('throws an AwilixResolutionError when there are cyclic dependencies', () => {
       const container = createContainer()
       container.register({
         first: asFunction((cradle: any) => cradle.second),
@@ -423,7 +423,7 @@ describe('container', function () {
       expect(err.message).toContain('first -> second -> third -> second')
     })
 
-    it('throws an AwilixResolutionError when the lifetime is unknown', function () {
+    it('throws an AwilixResolutionError when the lifetime is unknown', () => {
       const container = createContainer()
       container.register({
         first: asFunction((cradle: any) => cradle.second),
@@ -435,7 +435,7 @@ describe('container', function () {
       expect(err.message).toContain('lol')
     })
 
-    it('behaves properly when the cradle is returned from an async function', async function () {
+    it('behaves properly when the cradle is returned from an async function', async () => {
       const container = createContainer()
       container.register({ value: asValue(42) })
 
@@ -449,33 +449,33 @@ describe('container', function () {
     })
   })
 
-  describe('loadModules', function () {
+  describe('loadModules', () => {
     let container: AwilixContainer
-    beforeEach(function () {
+    beforeEach(() => {
       container = createContainer()
     })
 
-    it('returns the container', function () {
+    it('returns the container', () => {
       expect(container.loadModules([])).toBe(container)
     })
 
-    it('returns a Promise of the container if used with esModules true', async function () {
+    it('returns a Promise of the container if used with esModules true', async () => {
       expect(await container.loadModules([], { esModules: true })).toBe(
         container
       )
     })
   })
 
-  describe('setting a property on the cradle', function () {
-    it('should fail', function () {
+  describe('setting a property on the cradle', () => {
+    it('should fail', () => {
       expect(() => {
         createContainer().cradle.lol = 'nope'
       }).toThrowError(Error)
     })
   })
 
-  describe('using util.inspect on the container', function () {
-    it('should return a summary', function () {
+  describe('using util.inspect on the container', () => {
+    it('should return a summary', () => {
       const container = createContainer().register({
         val1: asValue(1),
         val2: asValue(2),
@@ -495,8 +495,8 @@ describe('container', function () {
     })
   })
 
-  describe('using util.inspect on the cradle', function () {
-    it('should return the preconfigured string', function () {
+  describe('using util.inspect on the cradle', () => {
+    it('should return the preconfigured string', () => {
       const container = createContainer().register({
         val1: asValue(1),
         val2: asValue(2),
@@ -515,8 +515,8 @@ describe('container', function () {
     })
   })
 
-  describe('using Array.from on the cradle', function () {
-    it('should return an Array with registration names', function () {
+  describe('using Array.from on the cradle', () => {
+    it('should return an Array with registration names', () => {
       const container = createContainer().register({
         val1: asValue(1),
         val2: asValue(2),
@@ -550,8 +550,8 @@ describe('container', function () {
     })
   })
 
-  describe('explicitly trying to fuck shit up', function () {
-    it('should prevent you from fucking shit up', function () {
+  describe('explicitly trying to fuck shit up', () => {
+    it('should prevent you from fucking shit up', () => {
       const container = createContainer({
         injectionMode: null as any,
       }).register({
@@ -567,7 +567,7 @@ describe('container', function () {
       expect(theAnswer()).toBe(42)
     })
 
-    it('should default to PROXY injection mode when unknown', function () {
+    it('should default to PROXY injection mode when unknown', () => {
       const container = createContainer({
         injectionMode: 'I dunno maaaang...' as any,
       }).register({
@@ -776,7 +776,7 @@ describe('memoizing registrations', () => {
     })
   })
 
-  describe('Safely stringify cradle', function () {
+  describe('Safely stringify cradle', () => {
     it('should have toJSON() return [AwilixContainer.cradle]', () => {
       expect(createContainer().cradle.toJSON()).toBe('[AwilixContainer.cradle]')
     })

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -4,8 +4,8 @@ const AnotherService =
   require('./fixture/services/anotherService').AnotherService
 const fixture = require('./fixture')
 
-describe('integration tests', function () {
-  it('bootstraps everything so the answer can be resolved', function () {
+describe('integration tests', () => {
+  it('bootstraps everything so the answer can be resolved', () => {
     const container = fixture()
     const anotherService = container.resolve('anotherService')
     expect(anotherService).toBeInstanceOf(AnotherService)
@@ -14,7 +14,7 @@ describe('integration tests', function () {
     expect(Object.keys(container.registrations).length).toBe(4)
   })
 
-  it('registered all services as scoped', function () {
+  it('registered all services as scoped', () => {
     const container = fixture()
     const scope1 = container.createScope()
     const scope2 = container.createScope()

--- a/src/__tests__/list-modules.test.ts
+++ b/src/__tests__/list-modules.test.ts
@@ -1,36 +1,36 @@
 import { listModules } from '../list-modules'
 
-describe('listModules', function () {
-  it('can find the modules in lib', function () {
+describe('listModules', () => {
+  it('can find the modules in lib', () => {
     const result = listModules('../*.ts', { cwd: __dirname })
     expect(result.some((x) => x.name === 'container')).toBeTruthy()
   })
 
-  it('can find the modules in src without cwd', function () {
+  it('can find the modules in src without cwd', () => {
     const result = listModules('src/*.ts')
     expect(result.some((x) => x.name === 'container')).toBeTruthy()
   })
 
-  it('handles dots in module names', function () {
+  it('handles dots in module names', () => {
     const result = listModules('*.{ts,js}', { cwd: __dirname })
     expect(result.find((x) => x.name === 'container.test')).toBeDefined()
   })
 
-  it('returns a path', function () {
+  it('returns a path', () => {
     const result = listModules('../*.ts', { cwd: __dirname })
     const createContainerModule = result.find((x) => x.name === 'container')!
     expect(createContainerModule.name).toBe('container')
     expect(createContainerModule.path).toContain('container.ts')
   })
 
-  it('supports an array of globs', function () {
+  it('supports an array of globs', () => {
     const result = listModules(['src/*.ts'])
     const createContainerModule = result.find((x) => x.name === 'container')!
     expect(createContainerModule.name).toBe('container')
     expect(createContainerModule.path).toContain('container.ts')
   })
 
-  it('supports array-opts syntax', function () {
+  it('supports array-opts syntax', () => {
     const opts = { value: 'yep' }
     const result = listModules([['src/*.ts', opts as any]])
 

--- a/src/__tests__/local-injections.test.ts
+++ b/src/__tests__/local-injections.test.ts
@@ -41,7 +41,7 @@ describe('local injections', function () {
     )
   })
 
-  it('supported by registerClass', function () {
+  it('supported by registerClass', () => {
     const container = createContainer().register({
       test: asClass(Test, { injector }),
       testClassic: asClass(TestClassic, {

--- a/src/__tests__/param-parser.test.ts
+++ b/src/__tests__/param-parser.test.ts
@@ -1,11 +1,11 @@
 import { parseParameterList } from '../param-parser'
 
-describe('parseParameterList', function () {
-  it('returns an empty array when invalid input is given', function () {
+describe('parseParameterList', () => {
+  it('returns an empty array when invalid input is given', () => {
     expect(parseParameterList('')).toEqual([])
   })
 
-  it('supports regular functions', function () {
+  it('supports regular functions', () => {
     expect(
       parseParameterList(
         function hello(dep1: any, dep2: any) {
@@ -53,7 +53,7 @@ describe('parseParameterList', function () {
     ).toEqual([])
   })
 
-  it('supports regular functions with default params', function () {
+  it('supports regular functions with default params', () => {
     expect(
       parseParameterList(
         `function hello(
@@ -68,7 +68,7 @@ describe('parseParameterList', function () {
     ])
   })
 
-  it('supports arrow functions', function () {
+  it('supports arrow functions', () => {
     expect(
       parseParameterList(
         ((dep1: any, dep2: any) => {
@@ -109,7 +109,7 @@ describe('parseParameterList', function () {
     ])
   })
 
-  it('supports arrow function with default params', function () {
+  it('supports arrow function with default params', () => {
     expect(
       parseParameterList(
         ((dep1 = 123, dep2 = 456) => {
@@ -128,7 +128,7 @@ describe('parseParameterList', function () {
     ])
   })
 
-  it('supports class constructors', function () {
+  it('supports class constructors', () => {
     class Test {
       dep1: any
       constructor(dep1: any, dep2: any) {
@@ -169,14 +169,14 @@ describe('parseParameterList', function () {
     ])
   })
 
-  it('supports carriage return in function signature', function () {
+  it('supports carriage return in function signature', () => {
     expect(parseParameterList(`function (\r\ndep1,\r\ndep2\r\n) {}`)).toEqual([
       { name: 'dep1', optional: false },
       { name: 'dep2', optional: false },
     ])
   })
 
-  it('supports weird formatting', function () {
+  it('supports weird formatting', () => {
     expect(
       parseParameterList(`function(  dep1    \n,\r\n  dep2 = 123 \r\n) {}`)
     ).toEqual([
@@ -185,7 +185,7 @@ describe('parseParameterList', function () {
     ])
   })
 
-  it('supports the problem posted in issue #30', function () {
+  it('supports the problem posted in issue #30', () => {
     const fn = function (a: any) {
       return {}
     }

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -7,14 +7,14 @@ import {
   uniq,
 } from '../utils'
 
-describe('flatten', function () {
-  it('flattens the array', function () {
+describe('flatten', () => {
+  it('flattens the array', () => {
     expect(flatten([[1, 2], [3]])).toEqual([1, 2, 3])
   })
 })
 
-describe('isClass', function () {
-  it('returns true for function that start with a capital letter', function () {
+describe('isClass', () => {
+  it('returns true for function that start with a capital letter', () => {
     expect(
       isClass(function Stuff() {
         /**/
@@ -22,7 +22,7 @@ describe('isClass', function () {
     ).toBe(true)
   })
 
-  it('returns false for function that do not start with a capital letter', function () {
+  it('returns false for function that do not start with a capital letter', () => {
     expect(
       isClass(function stuff() {
         /**/
@@ -30,19 +30,19 @@ describe('isClass', function () {
     ).toBe(false)
   })
 
-  it('returns false for other stuff', function () {
+  it('returns false for other stuff', () => {
     expect(isClass('hello' as any)).toBe(false)
     expect(isClass(123 as any)).toBe(false)
   })
 
-  it('returns true for classes', function () {
+  it('returns true for classes', () => {
     expect(isClass(class Stuff {})).toBe(true)
     expect(isClass(class {})).toBe(true)
   })
 })
 
-describe('isFunction', function () {
-  it('returns true when the value is a function', function () {
+describe('isFunction', () => {
+  it('returns true when the value is a function', () => {
     expect(
       isFunction(() => {
         /**/
@@ -56,7 +56,7 @@ describe('isFunction', function () {
     expect(isFunction(class {})).toBe(true)
   })
 
-  it('returns false when the value is not a function', function () {
+  it('returns false when the value is not a function', () => {
     expect(isFunction(true)).toBe(false)
     expect(isFunction(false)).toBe(false)
     expect(isFunction('')).toBe(false)
@@ -65,20 +65,20 @@ describe('isFunction', function () {
   })
 })
 
-describe('last', function () {
-  it('returns the last element', function () {
+describe('last', () => {
+  it('returns the last element', () => {
     expect(last([1, 2, 3])).toBe(3)
   })
 })
 
-describe('nameValueToObject', function () {
-  it('converts 2 params to 1', function () {
+describe('nameValueToObject', () => {
+  it('converts 2 params to 1', () => {
     const result = nameValueToObject('hello', 'world')
     expect(typeof result).toBe('object')
     expect(result.hello).toBe('world')
   })
 
-  it('uses the object if passed', function () {
+  it('uses the object if passed', () => {
     const input = { hello: 'world' }
     const result = nameValueToObject(input)
 


### PR DESCRIPTION
Hi,
while reading the tests I saw a few places declaring functions with `function ()` and other with `arrow functions`.
I imagine arrow functions are preferred so, to keep it consistent, updating all to use arrow functions.

Let me know if thats ok, 
Thanks!