### PR TITLE
Remove unused parameter from test.

### DIFF
--- a/src/__tests__/container.test.ts
+++ b/src/__tests__/container.test.ts
@@ -427,7 +427,7 @@ describe('container', function () {
       const container = createContainer()
       container.register({
         first: asFunction((cradle: any) => cradle.second),
-        second: asFunction((cradle: any) => 'hah', { lifetime: 'lol' as any }),
+        second: asFunction(() => 'hah', { lifetime: 'lol' as any }),
       })
 
       const err = throws(() => container.resolve('first'))


### PR DESCRIPTION
Removing the parameter `cradle` from the `second` registered function since it's not used.