### PR TITLE
chore(tests): remove unused desc from load-modules-test

### DIFF
--- a/src/__tests__/load-modules.test.ts
+++ b/src/__tests__/load-modules.test.ts
@@ -466,7 +466,7 @@ describe('loadModules', () => {
       }
 
       loadModules(deps, 'anything', {
-        formatName: (desc) => 'formatNameCalled',
+        formatName: () => 'formatNameCalled',
         resolverOptions: {
           lifetime: Lifetime.SCOPED,
         },


### PR DESCRIPTION
Removing un used `desc` from load.modules.test.