### PR TITLE
Match parameter types of `aliasTo` from `container.resolve`

### DIFF
--- a/src/__tests__/resolvers.test.ts
+++ b/src/__tests__/resolvers.test.ts
@@ -206,8 +206,14 @@ describe('registrations', () => {
   })
 
   describe('aliasTo', () => {
-    it('returns the aliased dependency', () => {
+    it('returns the string aliased dependency', () => {
       container.register({ val: asValue(123), aliasVal: aliasTo('val') })
+      expect(container.resolve('aliasVal')).toBe(123)
+    })
+
+    it('returns the symbol aliased dependency', () => {
+      const symbol = Symbol()
+      container.register({ [symbol]: asValue(123), aliasVal: aliasTo(symbol) })
       expect(container.resolve('aliasVal')).toBe(123)
     })
   })

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -214,10 +214,12 @@ export function asClass<T = {}>(
 /**
  * Resolves to the specified registration.
  */
-export function aliasTo<T>(name: string): Resolver<T> {
+export function aliasTo<T>(
+  ...args: Parameters<AwilixContainer['resolve']>
+): Resolver<T> {
   return {
     resolve(container) {
-      return container.resolve(name)
+      return container.resolve(...args)
     },
   }
 }

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -215,11 +215,11 @@ export function asClass<T = {}>(
  * Resolves to the specified registration.
  */
 export function aliasTo<T>(
-  ...args: Parameters<AwilixContainer['resolve']>
+  name: Parameters<AwilixContainer['resolve']>[0]
 ): Resolver<T> {
   return {
     resolve(container) {
-      return container.resolve(...args)
+      return container.resolve(name)
     },
   }
 }


### PR DESCRIPTION
Allow `aliasTo` to handle Symbol.