### PR TITLE
Add option to detect and error on dependency lifetime mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v10.0.0
+
+* Add (optional, off by default) strict mode to enforce extra correctness checks in both resolution
+  and registration
+* Reduce the publicly accessible API surface to only that which is needed to use Awilix. This is
+  potentially a breaking change if you were using any of the internal type definitions.
+
 # v9.0.0
 
 * Upgrade packages

--- a/README.md
+++ b/README.md
@@ -868,11 +868,7 @@ Args:
       **_must_** be named exactly like they are in the registration. For
       example, a dependency registered as `repository` cannot be referenced in a
       class constructor as `repo`.
-  - `options.strict`: Defaults to `false`; if `true`, will enable the following additional
-    correctness checks:
-    - Will throw an error if a singleton depends on a scoped or transient registration, or if a
-      scoped registration depends on a transient registration.
-    - Will throw an error if a singleton is registered on a scope other than the root container.
+  - `options.strict`: Enables [strict mode](#strict-mode). Defaults to `false`.
 
 ## `asFunction()`
 

--- a/README.md
+++ b/README.md
@@ -297,9 +297,6 @@ in the root container, and would always have the `currentUser` from the first
 request. Modules should generally not have a longer lifetime than their
 dependencies, as this can cause issues of stale data.
 
-If you want a mismatched configuration like the above to error, set
-`errorOnShorterLivedDependencies` in the container options.
-
 ```js
 const makePrintTime = ({ time }) => () => {
   console.log('Time:', time)
@@ -323,6 +320,11 @@ container.resolve('time')
 container.resolve('printTime')()
 container.resolve('printTime')()
 ```
+
+If you want a mismatched configuration like this to error, set
+`errorOnShorterLivedDependencies` in the container options. This will trigger
+the following error at runtime when the singleton `printTime` is resolved:
+`AwilixResolutionError: Could not resolve 'time'. Dependency 'time' has a shorter lifetime than its ancestor: 'printTime'`
 
 Read the documentation for [`container.createScope()`](#containercreatescope)
 for more examples.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Awilix enables you to write **composable, testable software** using dependency i
   - [`aliasTo()`](#aliasto)
   - [`listModules()`](#listmodules)
   - [`AwilixResolutionError`](#awilixresolutionerror)
+  - [`AwilixRegistrationError`](#awilixregistrationerror)
   - [The `AwilixContainer` object](#the-awilixcontainer-object)
     - [`container.cradle`](#containercradle)
     - [`container.registrations`](#containerregistrations)
@@ -954,6 +955,11 @@ This is a special error thrown when Awilix is unable to resolve all dependencies
 (due to missing or cyclic dependencies). You can catch this error and use
 `err instanceof AwilixResolutionError` if you wish. It will tell you what
 dependencies it could not find or which ones caused a cycle.
+
+## `AwilixRegistrationError`
+
+This is a special error thrown when Awilix is unable to register a dependency due to a strict mode
+violation. You can catch this error and use `err instanceof AwilixRegistrationError` if you wish.
 
 ## The `AwilixContainer` object
 

--- a/README.md
+++ b/README.md
@@ -346,12 +346,13 @@ checks that can help you catch bugs early.
 
 In particular, strict mode enables the following checks:
 
-- When a singleton depends on a scoped or transient registration, or when a scoped registration
-  depends on a transient registration, an error is thrown. This detects and prevents the issue where
-  a shorter lifetime dependency can leak outside its intended lifetime due to its preservation in a
-  longer lifetime module.
+- When a singleton or scoped registration depends on a transient non-value registration, an error is
+  thrown. This detects and prevents the issue where a shorter lifetime dependency can leak outside
+  its intended lifetime due to its preservation in a longer lifetime module.
 - Singleton registrations on any scopes are disabled. This prevents the issue where a singleton is
   registered on a scope other than the root container, which results in unpredictable behavior.
+- Singleton resolution is performed using registrations from the root container only, which prevents
+  potential leaks in which scoped registrations are preserved in singletons.
 
 # Injection modes
 
@@ -834,6 +835,8 @@ pass in an object with the following props:
   [Per-module local injections](#per-module-local-injections)
 - `register`: Only used in `loadModules`, determines how to register a loaded
   module explicitly
+- `isLeakSafe`: true if this resolver should be excluded from lifetime-leak checking performed in
+  [strict mode](#strict-mode). Defaults to false.
 
 **Examples of usage:**
 

--- a/README.md
+++ b/README.md
@@ -95,8 +95,10 @@ minimum, you need to do 3 things:
 const awilix = require('awilix')
 
 // Create the container and set the injectionMode to PROXY (which is also the default).
+// Enable detection and error on mismatched dependency lifetimes (highly recommended).
 const container = awilix.createContainer({
-  injectionMode: awilix.InjectionMode.PROXY
+  injectionMode: awilix.InjectionMode.PROXY,
+  errorOnShorterLivedDependencies: true
 })
 
 // This is our app code... We can use

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![JavaScript Style Guide](https://img.shields.io/badge/code%20style-standard-brightgreen.svg)](http://standardjs.com/)
 
 Extremely powerful, performant, & battle-tested **Dependency Injection** (DI) container for JavaScript/Node,
-written in [TypeScript](http://typescriptlang.org). 
+written in [TypeScript](http://typescriptlang.org).
 
 Awilix enables you to write **composable, testable software** using dependency injection **without special annotations**, which in turn decouples your core application code from the intricacies of the DI mechanism.
 
@@ -24,6 +24,7 @@ Awilix enables you to write **composable, testable software** using dependency i
 - [Usage](#usage)
 - [Lifetime management](#lifetime-management)
   - [Scoped lifetime](#scoped-lifetime)
+- [Strict mode](#strict-mode)
 - [Injection modes](#injection-modes)
 - [Auto-loading modules](#auto-loading-modules)
 - [Per-module local injections](#per-module-local-injections)
@@ -74,9 +75,9 @@ yarn add awilix
 You can also use the [UMD](https://github.com/umdjs/umd) build from `unpkg`
 
 ```html
-<script src="https://unpkg.com/awilix/lib/awilix.umd.js"/>
+<script src="https://unpkg.com/awilix/lib/awilix.umd.js" />
 <script>
-const container = Awilix.createContainer()
+  const container = Awilix.createContainer()
 </script>
 ```
 
@@ -95,10 +96,10 @@ minimum, you need to do 3 things:
 const awilix = require('awilix')
 
 // Create the container and set the injectionMode to PROXY (which is also the default).
-// Enable detection and error on mismatched dependency lifetimes (highly recommended).
+// Enable strict mode for extra correctness checks (highly recommended).
 const container = awilix.createContainer({
   injectionMode: awilix.InjectionMode.PROXY,
-  errorOnShorterLivedDependencies: true
+  strict: true,
 })
 
 // This is our app code... We can use
@@ -120,7 +121,7 @@ class UserController {
 container.register({
   // Here we are telling Awilix how to resolve a
   // userController: by instantiating a class.
-  userController: awilix.asClass(UserController)
+  userController: awilix.asClass(UserController),
 })
 
 // Let's try with a factory function.
@@ -128,16 +129,16 @@ const makeUserService = ({ db }) => {
   // Notice how we can use destructuring
   // to access dependencies
   return {
-    getUser: id => {
+    getUser: (id) => {
       return db.query(`select * from users where id=${id}`)
-    }
+    },
   }
 }
 
 container.register({
   // the `userService` is resolved by
   // invoking the function.
-  userService: awilix.asFunction(makeUserService)
+  userService: awilix.asFunction(makeUserService),
 })
 
 // Alright, now we need a database.
@@ -151,7 +152,7 @@ function Database(connectionString, timeout) {
   this.conn = connectToYourDatabaseSomehow(connectionString, timeout)
 }
 
-Database.prototype.query = function(sql) {
+Database.prototype.query = function (sql) {
   // blah....
   return this.conn.rawSql(sql)
 }
@@ -161,7 +162,7 @@ Database.prototype.query = function(sql) {
 // We also want to use `CLASSIC` injection mode for this
 // registration. Read more about injection modes below.
 container.register({
-  db: awilix.asClass(Database).classic()
+  db: awilix.asClass(Database).classic(),
 })
 
 // Lastly we register the connection string and timeout values
@@ -171,7 +172,7 @@ container.register({
   // limited to strings and numbers, it can be anything,
   // really - they will be passed through directly.
   connectionString: awilix.asValue(process.env.CONN_STR),
-  timeout: awilix.asValue(1000)
+  timeout: awilix.asValue(1000),
 })
 
 // We have now wired everything up!
@@ -221,17 +222,17 @@ const { asClass, asFunction, asValue } = awilix
 class MailService {}
 
 container.register({
-  mailService: asClass(MailService, { lifetime: Lifetime.SINGLETON })
+  mailService: asClass(MailService, { lifetime: Lifetime.SINGLETON }),
 })
 
 // or using the chaining configuration API..
 container.register({
-  mailService: asClass(MailService).setLifetime(Lifetime.SINGLETON)
+  mailService: asClass(MailService).setLifetime(Lifetime.SINGLETON),
 })
 
 // or..
 container.register({
-  mailService: asClass(MailService).singleton()
+  mailService: asClass(MailService).singleton(),
 })
 
 // or.......
@@ -262,7 +263,7 @@ class MessageService {
 }
 
 container.register({
-  messageService: asClass(MessageService).scoped()
+  messageService: asClass(MessageService).scoped(),
 })
 
 // imagine middleware in some web framework..
@@ -272,7 +273,7 @@ app.use((req, res, next) => {
 
   // register some request-specific data..
   req.scope.register({
-    currentUser: asValue(req.user)
+    currentUser: asValue(req.user),
   })
 
   next()
@@ -281,7 +282,7 @@ app.use((req, res, next) => {
 app.get('/messages', (req, res) => {
   // for each request we get a new message service!
   const messageService = req.scope.resolve('messageService')
-  messageService.getMessages().then(messages => {
+  messageService.getMessages().then((messages) => {
     res.send(200, messages)
   })
 })
@@ -300,15 +301,17 @@ request. Modules should generally not have a longer lifetime than their
 dependencies, as this can cause issues of stale data.
 
 ```js
-const makePrintTime = ({ time }) => () => {
-  console.log('Time:', time)
-}
+const makePrintTime =
+  ({ time }) =>
+  () => {
+    console.log('Time:', time)
+  }
 
 const getTime = () => new Date().toString()
 
 container.register({
   printTime: asFunction(makePrintTime).singleton(),
-  time: asFunction(getTime).transient()
+  time: asFunction(getTime).transient(),
 })
 
 // Resolving `time` 2 times will
@@ -324,12 +327,31 @@ container.resolve('printTime')()
 ```
 
 If you want a mismatched configuration like this to error, set
-`errorOnShorterLivedDependencies` in the container options. This will trigger
+`strict` in the container options. This will trigger
 the following error at runtime when the singleton `printTime` is resolved:
 `AwilixResolutionError: Could not resolve 'time'. Dependency 'time' has a shorter lifetime than its ancestor: 'printTime'`
 
+In addition, registering a singleton on a scope other than the root container results in
+unpredictable behavior. In particular, if two different singletons are registered on two different
+scopes, they will share a cache entry and collide with each other. To throw a runtime error when a
+singleton is registered on a scope other than the root container, set `strict` to true.
+
 Read the documentation for [`container.createScope()`](#containercreatescope)
 for more examples.
+
+# Strict mode
+
+Strict mode is a new feature in Awilix 9.1. It enables additional correctness
+checks that can help you catch bugs early.
+
+In particular, strict mode enables the following checks:
+
+- When a singleton depends on a scoped or transient registration, or when a scoped registration
+  depends on a transient registration, an error is thrown. This detects and prevents the issue where
+  a shorter lifetime dependency can leak outside its intended lifetime due to its preservation in a
+  longer lifetime module.
+- Singleton registrations on any scopes are disabled. This prevents the issue where a singleton is
+  registered on a scope other than the root container, which results in unpredictable behavior.
 
 # Injection modes
 
@@ -364,11 +386,11 @@ modes are available on `awilix.InjectionMode`
   ```
 
 - `InjectionMode.CLASSIC`: Parses the function/constructor parameters, and
-  matches them with registrations in the container. `CLASSIC` mode has a 
-  slightly higher initialization cost as it has to parse the function/class 
-  to figure out the dependencies at the time of registration, however resolving 
-  them will be **much faster** than when using `PROXY`. _Don't use `CLASSIC` if 
-  you minify your code!_ We recommend using `CLASSIC` in Node and `PROXY` in 
+  matches them with registrations in the container. `CLASSIC` mode has a
+  slightly higher initialization cost as it has to parse the function/class
+  to figure out the dependencies at the time of registration, however resolving
+  them will be **much faster** than when using `PROXY`. _Don't use `CLASSIC` if
+  you minify your code!_ We recommend using `CLASSIC` in Node and `PROXY` in
   environments where minification is needed.
 
   ```js
@@ -436,8 +458,8 @@ container.register({
 const container = createContainer()
 container.loadModules(['services/**/*.js', 'repositories/**/*.js'], {
   resolverOptions: {
-    injectionMode: InjectionMode.CLASSIC
-  }
+    injectionMode: InjectionMode.CLASSIC,
+  },
 })
 ```
 
@@ -477,7 +499,7 @@ function database({ connectionString, timeout, logger }) {
 const db = database({
   logger: new LoggerMock(),
   timeout: 4000,
-  connectionString: 'localhost:1337;user=123...'
+  connectionString: 'localhost:1337;user=123...',
 })
 ```
 
@@ -534,35 +556,38 @@ const awilix = require('awilix')
 const container = awilix.createContainer()
 
 // Load our modules!
-container.loadModules([
-  // Globs!
+container.loadModules(
   [
-    // To have different resolverOptions for specific modules.
-    'models/**/*.js',
-    {
-      register: awilix.asValue,
-      lifetime: Lifetime.SINGLETON
-    }
+    // Globs!
+    [
+      // To have different resolverOptions for specific modules.
+      'models/**/*.js',
+      {
+        register: awilix.asValue,
+        lifetime: Lifetime.SINGLETON,
+      },
+    ],
+    'services/**/*.js',
+    'repositories/**/*.js',
   ],
-  'services/**/*.js',
-  'repositories/**/*.js'
-], {
-  // We want to register `UserService` as `userService` -
-  // by default loaded modules are registered with the
-  // name of the file (minus the extension)
-  formatName: 'camelCase',
-  // Apply resolver options to all modules.
-  resolverOptions: {
-    // We can give these auto-loaded modules
-    // the deal of a lifetime! (see what I did there?)
-    // By default it's `TRANSIENT`.
-    lifetime: Lifetime.SINGLETON,
-    // We can tell Awilix what to register everything as,
-    // instead of guessing. If omitted, will inspect the
-    // module to determine what to register as.
-    register: awilix.asClass
-  }
-})
+  {
+    // We want to register `UserService` as `userService` -
+    // by default loaded modules are registered with the
+    // name of the file (minus the extension)
+    formatName: 'camelCase',
+    // Apply resolver options to all modules.
+    resolverOptions: {
+      // We can give these auto-loaded modules
+      // the deal of a lifetime! (see what I did there?)
+      // By default it's `TRANSIENT`.
+      lifetime: Lifetime.SINGLETON,
+      // We can tell Awilix what to register everything as,
+      // instead of guessing. If omitted, will inspect the
+      // module to determine what to register as.
+      register: awilix.asClass,
+    },
+  },
+)
 
 // We are now ready! We now have a userService, userRepository and emailService!
 container.resolve('userService').getUser(1)
@@ -588,10 +613,10 @@ export default function userRepository({ db, timeout }) {
       return Promise.race([
         db.query('select * from users'),
         Promise.delay(timeout).then(() =>
-          Promise.reject(new Error('Timed out'))
-        )
+          Promise.reject(new Error('Timed out')),
+        ),
       ])
-    }
+    },
   }
 }
 ```
@@ -610,22 +635,22 @@ const container = createContainer()
       // Provide an injection function that returns an object with locals.
       // The function is called once per resolve of the registration
       // it is attached to.
-      .inject(() => ({ timeout: 2000 }))
+      .inject(() => ({ timeout: 2000 })),
   })
 
   // Shorthand variants
   .register({
     userRepository: asFunction(createUserRepository, {
-      injector: () => ({ timeout: 2000 })
-    })
+      injector: () => ({ timeout: 2000 }),
+    }),
   })
 
   // Stringly-typed shorthand
   .register(
     'userRepository',
     asFunction(createUserRepository, {
-      injector: () => ({ timeout: 2000 })
-    })
+      injector: () => ({ timeout: 2000 }),
+    }),
   )
 
   // with `loadModules`
@@ -658,7 +683,7 @@ export default class AwesomeService {
 // `RESOLVER` is a Symbol.
 AwesomeService[RESOLVER] = {
   lifetime: Lifetime.SCOPED,
-  injectionMode: InjectionMode.CLASSIC
+  injectionMode: InjectionMode.CLASSIC,
 }
 ```
 
@@ -669,7 +694,7 @@ import { createContainer, asClass } from 'awilix'
 import AwesomeService from './services/awesome-service.js'
 
 const container = createContainer().register({
-  awesomeService: asClass(AwesomeService)
+  awesomeService: asClass(AwesomeService),
 })
 
 console.log(container.registrations.awesomeService.lifetime) // 'SCOPED'
@@ -733,7 +758,7 @@ function configureContainer() {
       .singleton()
       // This is called when the pool is going to be disposed.
       // If it returns a Promise, it will be awaited by `dispose`.
-      .disposer(pool => pool.end())
+      .disposer((pool) => pool.end()),
   })
 }
 
@@ -814,13 +839,13 @@ pass in an object with the following props:
 
 ```js
 container.register({
-  stuff: asClass(MyClass, { injectionMode: InjectionMode.CLASSIC })
+  stuff: asClass(MyClass, { injectionMode: InjectionMode.CLASSIC }),
 })
 
 container.loadModules([['some/path/to/*.js', { register: asClass }]], {
   resolverOptions: {
-    lifetime: Lifetime.SCOPED
-  }
+    lifetime: Lifetime.SCOPED,
+  },
 })
 ```
 
@@ -843,10 +868,11 @@ Args:
       **_must_** be named exactly like they are in the registration. For
       example, a dependency registered as `repository` cannot be referenced in a
       class constructor as `repo`.
-  - `options.errorOnShorterLivedDependencies`: If `true`, will throw an error if
-    a singleton depends on a scoped or transient registration, or if a scoped
-    registration depends on a transient registration. Defaults to
-    `false`.
+  - `options.strict`: Defaults to `false`; if `true`, will enable the following additional
+    correctness checks:
+    - Will throw an error if a singleton depends on a scoped or transient registration, or if a
+      scoped registration depends on a transient registration.
+    - Will throw an error if a singleton is registered on a scope other than the root container.
 
 ## `asFunction()`
 
@@ -886,7 +912,7 @@ Resolves the dependency specified.
 ```js
 container.register({
   val: asValue(123),
-  aliasVal: aliasTo('val')
+  aliasVal: aliasTo('val'),
 })
 
 container.resolve('aliasVal') === container.resolve('val')
@@ -959,7 +985,7 @@ Each scope has it's own cache, and checks the cache of it's ancestors.
 ```js
 let counter = 1
 container.register({
-  count: asFunction(() => counter++).singleton()
+  count: asFunction(() => counter++).singleton(),
 })
 
 container.cradle.count === 1
@@ -975,7 +1001,7 @@ Options passed to `createContainer` are stored here.
 
 ```js
 const container = createContainer({
-  injectionMode: InjectionMode.CLASSIC
+  injectionMode: InjectionMode.CLASSIC,
 })
 
 console.log(container.options.injectionMode) // 'CLASSIC'
@@ -991,7 +1017,7 @@ Resolves the registration with the given name. Used by the cradle.
 
 ```js
 container.register({
-  leet: asFunction(() => 1337)
+  leet: asFunction(() => 1337),
 })
 
 container.resolve('leet') === 1337
@@ -1039,14 +1065,14 @@ container.register('context', asClass(SessionContext))
 container.register({
   connectionString: asValue('localhost:1433;user=...'),
   mailService: asFunction(makeMailService, { lifetime: Lifetime.SINGLETON }),
-  context: asClass(SessionContext, { lifetime: Lifetime.SCOPED })
+  context: asClass(SessionContext, { lifetime: Lifetime.SCOPED }),
 })
 
 // `asClass` and `asFunction` also supports a fluid syntax.
 // This...
 container.register(
   'mailService',
-  asFunction(makeMailService).setLifetime(Lifetime.SINGLETON)
+  asFunction(makeMailService).setLifetime(Lifetime.SINGLETON),
 )
 // .. is the same as this:
 container.register('context', asClass(SessionContext).singleton())
@@ -1087,9 +1113,9 @@ Args:
   pass the name through as-is. The 2nd parameter is a full module descriptor.
 - `opts.resolverOptions`: An `object` passed to the resolvers. Used to configure
   the lifetime, injection mode and more of the loaded modules.
-- `opts.esModules`: Loads modules using Node's native ES modules. 
-  **This makes `container.loadModules` asynchronous, and will therefore return a `Promise`!** 
-  This is only  supported on Node 14.0+ and should only be used if you're using 
+- `opts.esModules`: Loads modules using Node's native ES modules.
+  **This makes `container.loadModules` asynchronous, and will therefore return a `Promise`!**
+  This is only supported on Node 14.0+ and should only be used if you're using
   the [Native Node ES modules](https://nodejs.org/api/esm.html)
 
 Example:
@@ -1166,7 +1192,7 @@ inside a scope. A scope is basically a "child" container.
 // Increments the counter every time it is resolved.
 let counter = 1
 container.register({
-  counterValue: asFunction(() => counter++).scoped()
+  counterValue: asFunction(() => counter++).scoped(),
 })
 const scope1 = container.createScope()
 const scope2 = container.createScope()
@@ -1186,7 +1212,7 @@ A _Scope_ maintains it's own cache of `Lifetime.SCOPED` registrations, meaning i
 ```js
 let counter = 1
 container.register({
-  counterValue: asFunction(() => counter++).scoped()
+  counterValue: asFunction(() => counter++).scoped(),
 })
 const scope1 = container.createScope()
 const scope2 = container.createScope()
@@ -1212,13 +1238,13 @@ that scope and it's children.
 // that returns the value of the scope-provided dependency.
 // For this example we could also use scoped lifetime.
 container.register({
-  scopedValue: asFunction(cradle => 'Hello ' + cradle.someValue)
+  scopedValue: asFunction((cradle) => 'Hello ' + cradle.someValue),
 })
 
 // Create a scope and register a value.
 const scope = container.createScope()
 scope.register({
-  someValue: asValue('scope')
+  someValue: asValue('scope'),
 })
 
 scope.cradle.scopedValue === 'Hello scope'
@@ -1228,26 +1254,35 @@ container.cradle.someValue
 // of the resolver.
 ```
 
-Things registered in the scope take precedence over it's parent.
+Things registered in the scope take precedence over registrations in the parent scope(s). This
+applies to both the registration directly requested from the scope container, and any dependencies
+that the registration uses.
 
 ```js
 // It does not matter when the scope is created,
 // it will still have anything that is registered
-// in it's parent.
+// in its parent.
 const scope = container.createScope()
 
 container.register({
   value: asValue('root'),
-  usedValue: asFunction(cradle => cradle.value)
+  usedValue: asFunction((cradle) => `hello from ${cradle.value}`),
 })
 
 scope.register({
-  value: asValue('scope')
+  value: asValue('scope'),
 })
 
-container.cradle.usedValue === 'root'
-scope.cradle.usedValue === 'scope'
+container.cradle.value === 'root'
+scope.cradle.value === 'scope'
+container.cradle.usedValue === 'hello from root'
+scope.cradle.usedValue === 'hello from scope'
 ```
+
+Registering singletons in a scope results in unpredictable behavior and should be avoided. Having
+more than one singleton with the same name in different scopes will result in them sharing a cache
+entry and colliding with each other. To disallow such registrations, enable
+[strict mode](#strict-mode) in the container options.
 
 ### `container.build()`
 
@@ -1283,11 +1318,11 @@ class MyClass {
 }
 
 const createMyFunc = ({ ping }) => ({
-  pong: () => ping
+  pong: () => ping,
 })
 
 container.register({
-  ping: asValue('pong')
+  ping: asValue('pong'),
 })
 
 // Shorthand
@@ -1321,9 +1356,9 @@ const pg = require('pg')
 
 container.register({
   pool: asFunction(() => new pg.Pool())
-    .disposer(pool => pool.end())
+    .disposer((pool) => pool.end())
     // IMPORTANT! Must be either singleton or scoped!
-    .singleton()
+    .singleton(),
 })
 
 const pool = container.resolve('pool')
@@ -1365,11 +1400,11 @@ because they depend on Node-specific packages.
 
 # Ecosystem
 
-* [`awilix-manager`](https://github.com/kibertoad/awilix-manager): Wrapper that allows eager injection, asynchronous init methods and dependency lookup by tags.
-* [`awilix-express`](https://github.com/jeffijoe/awilix-express): Bindings for the Express HTTP library.
-* [`awilix-koa`](https://github.com/jeffijoe/awilix-koa): Bindings for the Koa HTTP library.
-* [`awilix-router-core`](https://github.com/jeffijoe/awilix-router-core): Library for building HTTP bindings for Awilix with routing.
-* [`fastify-awilix`](https://github.com/fastify/fastify-awilix): Bindings for the Fastify framework.
+- [`awilix-manager`](https://github.com/kibertoad/awilix-manager): Wrapper that allows eager injection, asynchronous init methods and dependency lookup by tags.
+- [`awilix-express`](https://github.com/jeffijoe/awilix-express): Bindings for the Express HTTP library.
+- [`awilix-koa`](https://github.com/jeffijoe/awilix-koa): Bindings for the Koa HTTP library.
+- [`awilix-router-core`](https://github.com/jeffijoe/awilix-router-core): Library for building HTTP bindings for Awilix with routing.
+- [`fastify-awilix`](https://github.com/fastify/fastify-awilix): Bindings for the Fastify framework.
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -289,7 +289,16 @@ app.get('/messages', (req, res) => {
 ```
 
 **IMPORTANT!** If a singleton is resolved, and it depends on a scoped or
-transient registration, those will remain in the singleton for it's lifetime!
+transient registration, those will remain in the singleton for its lifetime!
+Similarly, if a scoped module is resolved, and it depends on a transient
+registration, that remains in the scoped module for its lifetime.
+In the example above, if `messageService` was a singleton, it would be cached
+in the root container, and would always have the `currentUser` from the first
+request. Modules should generally not have a longer lifetime than their
+dependencies, as this can cause issues of stale data.
+
+If you want a mismatched configuration like the above to error, set
+`errorOnShorterLivedDependencies` in the container options.
 
 ```js
 const makePrintTime = ({ time }) => () => {
@@ -830,6 +839,10 @@ Args:
       **_must_** be named exactly like they are in the registration. For
       example, a dependency registered as `repository` cannot be referenced in a
       class constructor as `repo`.
+  - `options.errorOnShorterLivedDependencies`: If `true`, will throw an error if
+    a singleton depends on a scoped or transient registration, or if a scoped
+    registration depends on a transient registration. Defaults to
+    `false`.
 
 ## `asFunction()`
 

--- a/README.md
+++ b/README.md
@@ -335,15 +335,15 @@ the following error at runtime when the singleton `printTime` is resolved:
 In addition, registering a singleton on a scope other than the root container results in
 unpredictable behavior. In particular, if two different singletons are registered on two different
 scopes, they will share a cache entry and collide with each other. To throw a runtime error when a
-singleton is registered on a scope other than the root container, set `strict` to true.
+singleton is registered on a scope other than the root container, enable [strict mode](#strict-mode).
 
 Read the documentation for [`container.createScope()`](#containercreatescope)
 for more examples.
 
 # Strict mode
 
-Strict mode is a new feature in Awilix 9.1. It enables additional correctness
-checks that can help you catch bugs early.
+Strict mode is a new feature in Awilix 10. It enables additional correctness checks that can help
+you catch bugs early.
 
 In particular, strict mode enables the following checks:
 

--- a/examples/babel/.babelrc
+++ b/examples/babel/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["env"]
+  "presets": ["es2015"]
 }

--- a/examples/babel/src/index.js
+++ b/examples/babel/src/index.js
@@ -4,6 +4,7 @@ import { DependentService } from './services/dependentService'
 
 const container = createContainer({
   injectionMode: InjectionMode.CLASSIC,
+  errorOnShorterLivedDependencies: true,
 })
 
 container.register({

--- a/examples/babel/src/index.js
+++ b/examples/babel/src/index.js
@@ -4,7 +4,7 @@ import { DependentService } from './services/dependentService'
 
 const container = createContainer({
   injectionMode: InjectionMode.CLASSIC,
-  errorOnShorterLivedDependencies: true,
+  strict: true,
 })
 
 container.register({

--- a/examples/koa/index.js
+++ b/examples/koa/index.js
@@ -13,14 +13,16 @@ const app = new Koa()
 const router = new KoaRouter()
 
 // Create a container.
-const container = createContainer()
+const container = createContainer({ errorOnShorterLivedDependencies: true })
 
-// Register usefull stuff
+// Register useful stuff
 const MessageService = require('./services/MessageService')
 const makeMessageRepository = require('./repositories/messageRepository')
 container.register({
-  // used by the repository.
-  DB_CONNECTION_STRING: asValue('localhost:1234'),
+  // used by the repository; registered.
+  DB_CONNECTION_STRING: asValue('localhost:1234', {
+    lifetime: awilix.Lifetime.SINGLETON,
+  }),
   // resolved for each request.
   messageService: asClass(MessageService).scoped(),
   // only resolved once

--- a/examples/koa/index.js
+++ b/examples/koa/index.js
@@ -13,7 +13,7 @@ const app = new Koa()
 const router = new KoaRouter()
 
 // Create a container.
-const container = createContainer({ errorOnShorterLivedDependencies: true })
+const container = createContainer({ strict: true })
 
 // Register useful stuff
 const MessageService = require('./services/MessageService')

--- a/examples/simple/index.js
+++ b/examples/simple/index.js
@@ -2,7 +2,9 @@
 const awilix = require('../..')
 
 // Create a container.
-const container = awilix.createContainer()
+const container = awilix.createContainer({
+  errorOnShorterLivedDependencies: true,
+})
 
 // Register some value.. We depend on this in `Stuffs.js`
 container.register('database', awilix.asValue('stuffs_db'))

--- a/examples/simple/index.js
+++ b/examples/simple/index.js
@@ -3,7 +3,7 @@ const awilix = require('../..')
 
 // Create a container.
 const container = awilix.createContainer({
-  errorOnShorterLivedDependencies: true,
+  strict: true,
 })
 
 // Register some value.. We depend on this in `Stuffs.js`

--- a/examples/typescript/src/index.ts
+++ b/examples/typescript/src/index.ts
@@ -1,5 +1,5 @@
 // This is largely for testing, but import what we need
-import { createContainer, asClass, InjectionMode } from '../../../src/awilix'
+import { createContainer, asClass, InjectionMode } from '../../..'
 import TestService from './services/TestService'
 import DependentService from './services/DependentService'
 
@@ -11,6 +11,7 @@ interface ICradle {
 // Create the container
 const container = createContainer<ICradle>({
   injectionMode: InjectionMode.CLASSIC,
+  errorOnShorterLivedDependencies: true,
 })
 
 // Register the classes

--- a/examples/typescript/src/index.ts
+++ b/examples/typescript/src/index.ts
@@ -11,7 +11,7 @@ interface ICradle {
 // Create the container
 const container = createContainer<ICradle>({
   injectionMode: InjectionMode.CLASSIC,
-  errorOnShorterLivedDependencies: true,
+  strict: true,
 })
 
 // Register the classes

--- a/examples/typescript/tsconfig.json
+++ b/examples/typescript/tsconfig.json
@@ -5,8 +5,9 @@
     "outDir": "dist",
     "sourceMap": false,
     "target": "es5",
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "rootDir": "./src",
   },
-  "include": ["src/**/*.ts"],
+  "include": ["**/*.ts"],
   "exclude": ["dist", "node_modules"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "awilix",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "awilix",
-      "version": "9.0.0",
+      "version": "10.0.0",
       "license": "MIT",
       "dependencies": {
         "camel-case": "^4.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "typescript": "^5.2.2"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "awilix",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Extremely powerful dependency injection container.",
   "main": "lib/awilix.js",
   "module": "lib/awilix.module.mjs",

--- a/src/__tests__/container.test.ts
+++ b/src/__tests__/container.test.ts
@@ -452,9 +452,9 @@ describe('container', () => {
       expect(container.resolve('first')).toBe('hah')
     })
 
-    it('throws an AwilixResolutionError when longer lifetime modules depend on shorter lifetime dependencies and errorOnShorterLivedDependencies is set', () => {
+    it('throws an AwilixResolutionError when longer lifetime modules depend on shorter lifetime dependencies and strict is set', () => {
       const container = createContainer({
-        errorOnShorterLivedDependencies: true,
+        strict: true,
       })
       container.register({
         first: asFunction((cradle: any) => cradle.second, {
@@ -470,9 +470,9 @@ describe('container', () => {
       )
     })
 
-    it('does not throw an error when an injector proxy is used and errorOnShorterLivedDependencies is set', () => {
+    it('does not throw an error when an injector proxy is used and strict is set', () => {
       const container = createContainer({
-        errorOnShorterLivedDependencies: true,
+        strict: true,
       })
       container.register({
         first: asFunction((cradle: any) => cradle.injected, {
@@ -483,9 +483,9 @@ describe('container', () => {
       expect(container.resolve('first')).toBe('hah')
     })
 
-    it('allows for asValue() to be used when errorOnShorterLivedDependencies is set', () => {
+    it('allows for asValue() to be used when strict is set', () => {
       const container = createContainer({
-        errorOnShorterLivedDependencies: true,
+        strict: true,
       })
       container.register({
         first: asFunction((cradle: any) => cradle.val, {
@@ -502,9 +502,9 @@ describe('container', () => {
       expect(container.resolve('second')).toBe('foobar')
     })
 
-    it('correctly errors when a singleton parent depends on a scoped value and errorOnShorterLivedDependencies is set', () => {
+    it('correctly errors when a singleton parent depends on a scoped value and strict is set', () => {
       const container = createContainer({
-        errorOnShorterLivedDependencies: true,
+        strict: true,
       })
       container.register({
         first: asFunction((cradle: any) => cradle.second, {

--- a/src/__tests__/container.test.ts
+++ b/src/__tests__/container.test.ts
@@ -729,6 +729,25 @@ describe('container', () => {
 
         expect(scope.resolve('singleton')).toBe('hah')
       })
+
+      it('preserves the resolution stack when resolving a singleton using a parent container, from a scope', () => {
+        const container = createContainer({
+          strict: true,
+        })
+        container.register({
+          scoped: asFunction((cradle: any) => cradle.singleton, {
+            lifetime: Lifetime.SCOPED,
+          }),
+          singleton: asFunction((cradle: any) => cradle.val, {
+            lifetime: Lifetime.SINGLETON,
+          }),
+        })
+        const scope = container.createScope()
+
+        const err = throws(() => scope.resolve('scoped'))
+        expect(err).toBeInstanceOf(AwilixResolutionError)
+        expect(err.message).toContain('scoped -> singleton -> val')
+      })
     })
 
     describe('singleton registration on scope check', () => {

--- a/src/__tests__/container.test.ts
+++ b/src/__tests__/container.test.ts
@@ -466,7 +466,7 @@ describe('container', () => {
       const err = throws(() => container.resolve('first'))
       expect(err.message).toContain('first -> second')
       expect(err.message).toContain(
-        "Dependency 'second' has a shorter lifetime than its parent: 'first'",
+        "Dependency 'second' has a shorter lifetime than its ancestor: 'first'",
       )
     })
 
@@ -516,7 +516,7 @@ describe('container', () => {
       const err = throws(() => container.resolve('first'))
       expect(err.message).toContain('first -> second')
       expect(err.message).toContain(
-        "Dependency 'second' has a shorter lifetime than its parent: 'first'",
+        "Dependency 'second' has a shorter lifetime than its ancestor: 'first'",
       )
     })
 

--- a/src/__tests__/container.test.ts
+++ b/src/__tests__/container.test.ts
@@ -470,6 +470,19 @@ describe('container', () => {
       )
     })
 
+    it('does not throw an error when an injector proxy is used and errorOnShorterLivedDependencies is set', () => {
+      const container = createContainer({
+        errorOnShorterLivedDependencies: true,
+      })
+      container.register({
+        first: asFunction((cradle: any) => cradle.injected, {
+          lifetime: Lifetime.SCOPED,
+        }).inject(() => ({ injected: 'hah' })),
+      })
+
+      expect(container.resolve('first')).toBe('hah')
+    })
+
     it('behaves properly when the cradle is returned from an async function', async () => {
       const container = createContainer()
       container.register({ value: asValue(42) })

--- a/src/__tests__/container.test.ts
+++ b/src/__tests__/container.test.ts
@@ -631,6 +631,7 @@ describe('container', () => {
           first: asFunction((cradle: any) => cradle.injected, {
             lifetime: Lifetime.SCOPED,
           }).inject(() => ({ injected: 'hah' })),
+          injected: asFunction(() => 'foobar'),
         })
 
         expect(container.resolve('first')).toBe('hah')

--- a/src/__tests__/lifetime.test.ts
+++ b/src/__tests__/lifetime.test.ts
@@ -1,0 +1,15 @@
+import { Lifetime, isLifetimeLonger } from '../lifetime'
+
+describe('isLifetimeLonger', () => {
+  it('correctly compares lifetimes', () => {
+    expect(isLifetimeLonger(Lifetime.TRANSIENT, Lifetime.TRANSIENT)).toBe(false)
+    expect(isLifetimeLonger(Lifetime.TRANSIENT, Lifetime.SCOPED)).toBe(false)
+    expect(isLifetimeLonger(Lifetime.TRANSIENT, Lifetime.SINGLETON)).toBe(false)
+    expect(isLifetimeLonger(Lifetime.SCOPED, Lifetime.TRANSIENT)).toBe(true)
+    expect(isLifetimeLonger(Lifetime.SCOPED, Lifetime.SCOPED)).toBe(false)
+    expect(isLifetimeLonger(Lifetime.SCOPED, Lifetime.SINGLETON)).toBe(false)
+    expect(isLifetimeLonger(Lifetime.SINGLETON, Lifetime.TRANSIENT)).toBe(true)
+    expect(isLifetimeLonger(Lifetime.SINGLETON, Lifetime.SCOPED)).toBe(true)
+    expect(isLifetimeLonger(Lifetime.SINGLETON, Lifetime.SINGLETON)).toBe(false)
+  })
+})

--- a/src/awilix.ts
+++ b/src/awilix.ts
@@ -1,6 +1,24 @@
-export * from './errors'
-export * from './list-modules'
-export * from './container'
-export * from './resolvers'
-export * from './injection-mode'
-export * from './lifetime'
+export { AwilixContainer, ContainerOptions, createContainer } from './container'
+export {
+  AwilixError,
+  AwilixRegistrationError,
+  AwilixResolutionError,
+  AwilixTypeError,
+} from './errors'
+export { InjectionMode, InjectionModeType } from './injection-mode'
+export { Lifetime, LifetimeType } from './lifetime'
+export {
+  GlobWithOptions,
+  ListModulesOptions,
+  ModuleDescriptor,
+  listModules,
+} from './list-modules'
+export {
+  BuildResolverOptions,
+  Disposer,
+  InjectorFunction,
+  aliasTo,
+  asClass,
+  asFunction,
+  asValue,
+} from './resolvers'

--- a/src/container.ts
+++ b/src/container.ts
@@ -5,7 +5,7 @@ import {
   AwilixTypeError,
 } from './errors'
 import { InjectionMode, InjectionModeType } from './injection-mode'
-import { Lifetime, isLifetimeLonger } from './lifetime'
+import { Lifetime, LifetimeType, isLifetimeLonger } from './lifetime'
 import { GlobWithOptions, listModules } from './list-modules'
 import { importModule } from './load-module-native.js'
 import {
@@ -21,7 +21,6 @@ import {
   asClass,
   asFunction,
 } from './resolvers'
-import { ResolutionStack } from './types'
 import { isClass, last, nameValueToObject } from './utils'
 
 /**
@@ -200,6 +199,11 @@ export interface ContainerOptions {
  */
 export type RegistrationHash = Record<string | symbol | number, Resolver<any>>
 
+export type ResolutionStack = Array<{
+  name: string | symbol
+  lifetime: LifetimeType
+}>
+
 /**
  * Family tree symbol.
  */
@@ -228,11 +232,10 @@ const CRADLE_STRING_TAG = 'AwilixContainerCradle'
  *
  * @return {AwilixContainer<T>} The container.
  */
-export function createContainer<T extends object = any, U extends object = any>(
+export function createContainer<T extends object = any>(
   options: ContainerOptions = {},
-  parentContainer?: AwilixContainer<U>,
 ): AwilixContainer<T> {
-  return createContainerInternal(options, parentContainer)
+  return createContainerInternal(options)
 }
 
 function createContainerInternal<

--- a/src/container.ts
+++ b/src/container.ts
@@ -512,7 +512,7 @@ export function createContainer<T extends object = any, U extends object = any>(
           throw new AwilixResolutionError(
             name,
             resolutionStack,
-            `Dependency '${name.toString()}' has a shorter lifetime than its parent: '${resolutionStack[
+            `Dependency '${name.toString()}' has a shorter lifetime than its ancestor: '${resolutionStack[
               maybeLongerLifetimeParentIndex
             ].name.toString()}'`,
           )

--- a/src/container.ts
+++ b/src/container.ts
@@ -543,8 +543,9 @@ export function createContainer<T extends object = any, U extends object = any>(
         case Lifetime.SCOPED:
           // Scoped lifetime means that the container
           // that resolves the registration also caches it.
-          // When a registration is not found, we travel up
-          // the family tree until we find one that is cached.
+          // If this container cache does not have it,
+          // resolve and cache it rather than using the parent
+          // container's cache.
           cached = container.cache.get(name)
           if (cached !== undefined) {
             // We found one!

--- a/src/container.ts
+++ b/src/container.ts
@@ -187,7 +187,7 @@ export type ClassOrFunctionReturning<T> = FunctionReturning<T> | Constructor<T>
 export interface ContainerOptions {
   require?: (id: string) => any
   injectionMode?: InjectionModeType
-  errorOnShorterLivedDependencies?: boolean
+  strict?: boolean
 }
 
 /**
@@ -219,21 +219,23 @@ const CRADLE_STRING_TAG = 'AwilixContainerCradle'
 /**
  * Creates an Awilix container instance.
  *
- * @param {Function} options.require
- * The require function to use. Defaults to require.
+ * @param {Function} options.require The require function to use. Defaults to require.
  *
- * @param {string} options.injectionMode
- * The mode used by the container to resolve dependencies. Defaults to 'Proxy'.
+ * @param {string} options.injectionMode The mode used by the container to resolve dependencies.
+ * Defaults to 'Proxy'.
  *
- * @return {AwilixContainer<T>}
- * The container.
+ * @param {boolean} options.strict True if the container should run in strict mode with additional
+ * validation for resolver dependency correctness. Defaults to false.
+ *
+ * @return {AwilixContainer<T>} The container.
  */
 export function createContainer<T extends object = any, U extends object = any>(
-  options?: ContainerOptions,
+  options: ContainerOptions = {},
   parentContainer?: AwilixContainer<U>,
 ): AwilixContainer<T> {
   options = {
     injectionMode: InjectionMode.PROXY,
+    strict: false,
     ...options,
   }
 
@@ -503,7 +505,7 @@ export function createContainer<T extends object = any, U extends object = any>(
 
       // if any of the parents have a shorter lifetime than the one requested,
       // and the container is configured to do so, throw an error.
-      if (options?.errorOnShorterLivedDependencies) {
+      if (options?.strict) {
         const maybeLongerLifetimeParentIndex = resolutionStack.findIndex(
           ({ lifetime: parentLifetime }) =>
             isLifetimeLonger(parentLifetime, lifetime),

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -151,3 +151,24 @@ export class AwilixResolutionError extends AwilixError {
     super(msg)
   }
 }
+
+/**
+ * A nice error class so we can do an instanceOf check.
+ */
+export class AwilixRegistrationError extends AwilixError {
+  /**
+   * Constructor, takes the registered modules and unresolved tokens
+   * to create a message.
+   *
+   * @param {string|symbol} name
+   * The name of the module that could not be registered.
+   */
+  constructor(name: string | symbol, message?: string) {
+    const stringName = name.toString()
+    let msg = `Could not register '${stringName}'.`
+    if (message) {
+      msg += ` ${message}`
+    }
+    super(msg)
+  }
+}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,4 +1,4 @@
-import { ResolutionStack } from './container'
+import { ResolutionStack } from './types'
 
 /**
  * Newline.

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -137,15 +137,11 @@ export class AwilixResolutionError extends AwilixError {
     resolutionStack: ResolutionStack,
     message?: string,
   ) {
-    if (typeof name === 'symbol') {
-      name = (name as any).toString()
-    }
-    resolutionStack = resolutionStack.map((val) =>
-      typeof val === 'symbol' ? (val as any).toString() : val,
-    )
-    resolutionStack.push(name)
-    const resolutionPathString = resolutionStack.join(' -> ')
-    let msg = `Could not resolve '${name as any}'.`
+    const stringName = name.toString()
+    const nameStack = resolutionStack.map(({ name: val }) => val.toString())
+    nameStack.push(stringName)
+    const resolutionPathString = nameStack.join(' -> ')
+    let msg = `Could not resolve '${stringName}'.`
     if (message) {
       msg += ` ${message}`
     }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,4 +1,4 @@
-import { ResolutionStack } from './types'
+import { ResolutionStack } from './container'
 
 /**
  * Newline.

--- a/src/lifetime.ts
+++ b/src/lifetime.ts
@@ -26,6 +26,9 @@ export const Lifetime: Record<LifetimeType, LifetimeType> = {
   SCOPED: 'SCOPED',
 }
 
+/**
+ * Returns true if and only if the first lifetime is strictly longer than the second.
+ */
 export function isLifetimeLonger(a: LifetimeType, b: LifetimeType): boolean {
   return (
     (a === Lifetime.SINGLETON && b !== Lifetime.SINGLETON) ||

--- a/src/lifetime.ts
+++ b/src/lifetime.ts
@@ -25,3 +25,10 @@ export const Lifetime: Record<LifetimeType, LifetimeType> = {
    */
   SCOPED: 'SCOPED',
 }
+
+export function isLifetimeLonger(a: LifetimeType, b: LifetimeType): boolean {
+  return (
+    (a === Lifetime.SINGLETON && b !== Lifetime.SINGLETON) ||
+    (a === Lifetime.SCOPED && b === Lifetime.TRANSIENT)
+  )
+}

--- a/src/load-modules.ts
+++ b/src/load-modules.ts
@@ -1,16 +1,16 @@
+import { camelCase } from 'camel-case'
 import { pathToFileURL } from 'url'
-import { ModuleDescriptor, GlobWithOptions, listModules } from './list-modules'
+import { AwilixContainer } from './container'
 import { Lifetime } from './lifetime'
+import { GlobWithOptions, ModuleDescriptor, listModules } from './list-modules'
 import {
+  BuildResolver,
+  BuildResolverOptions,
   RESOLVER,
   asClass,
   asFunction,
-  BuildResolverOptions,
 } from './resolvers'
-import { AwilixContainer } from './container'
 import { isClass, isFunction } from './utils'
-import { BuildResolver } from './awilix'
-import { camelCase } from 'camel-case'
 
 /**
  * Metadata of the module as well as the loaded module itself.

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -116,6 +116,7 @@ export type Constructor<T> = { new (...args: any[]): T }
 
 /**
  * Creates a simple value resolver where the given value will always be resolved.
+ * The lifetime of the resolved value defaults to `Lifetime.SCOPED`.
  *
  * @param  {string} name
  * The name to register the value as.
@@ -123,12 +124,16 @@ export type Constructor<T> = { new (...args: any[]): T }
  * @param  {*} value
  * The value to resolve.
  *
+ * @param {object} opts
+ * Additional options for this resolver.
+ *
  * @return {object}
  * The resolver.
  */
-export function asValue<T>(value: T): Resolver<T> {
+export function asValue<T>(value: T, opts?: ResolverOptions<T>): Resolver<T> {
   return {
     resolve: () => value,
+    ...{ lifetime: Lifetime.SCOPED, ...opts },
   }
 }
 

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -30,6 +30,7 @@ export type InjectorFunction = <T extends object>(
  */
 export interface Resolver<T> extends ResolverOptions<T> {
   resolve<U extends object>(container: AwilixContainer<U>): T
+  isValue: boolean
 }
 
 /**
@@ -115,26 +116,20 @@ export interface BuildResolverOptions<T>
 export type Constructor<T> = { new (...args: any[]): T }
 
 /**
- * Creates a simple value resolver where the given value will always be resolved.
- * The lifetime of the resolved value defaults to `Lifetime.SCOPED`.
+ * Creates a simple value resolver where the given value will always be resolved. The lifetime of
+ * the resolved value defaults to `Lifetime.SCOPED` if registered on a scoped container, and
+ * `Lifetime.SINGLETON` if registered on the root container.
  *
- * @param  {string} name
- * The name to register the value as.
+ * @param  {string} name The name to register the value as.
  *
- * @param  {*} value
- * The value to resolve.
+ * @param  {*} value The value to resolve.
  *
- * @param {object} opts
- * Additional options for this resolver.
- *
- * @return {object}
- * The resolver.
+ * @return {object} The resolver.
  */
-export function asValue<T>(value: T, opts?: ResolverOptions<T>): Resolver<T> {
+export function asValue<T>(value: T): Resolver<T> {
   return {
     resolve: () => value,
-    lifetime: Lifetime.SCOPED,
-    ...opts,
+    isValue: true,
   }
 }
 
@@ -171,6 +166,7 @@ export function asFunction<T>(
   const resolve = generateResolve(fn)
   const result = {
     resolve,
+    isValue: false,
     ...opts,
   }
 
@@ -215,6 +211,7 @@ export function asClass<T = object>(
   return createDisposableResolver(
     createBuildResolver({
       ...opts,
+      isValue: false,
       resolve,
     }),
   )
@@ -230,6 +227,7 @@ export function aliasTo<T>(
     resolve(container) {
       return container.resolve(name)
     },
+    isValue: false,
   }
 }
 

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -239,7 +239,7 @@ export function aliasTo<T>(
  * @return {object}
  * The interface.
  */
-export function createBuildResolver<T, B extends Resolver<T>>(
+function createBuildResolver<T, B extends Resolver<T>>(
   obj: B,
 ): BuildResolver<T> & B {
   function setLifetime(this: any, value: LifetimeType) {
@@ -280,7 +280,7 @@ export function createBuildResolver<T, B extends Resolver<T>>(
  * function.
  * @param obj
  */
-export function createDisposableResolver<T, B extends Resolver<T>>(
+function createDisposableResolver<T, B extends Resolver<T>>(
   obj: B,
 ): DisposableResolver<T> & B {
   function disposer(this: any, dispose: Disposer<T>) {

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -133,7 +133,8 @@ export type Constructor<T> = { new (...args: any[]): T }
 export function asValue<T>(value: T, opts?: ResolverOptions<T>): Resolver<T> {
   return {
     resolve: () => value,
-    ...{ lifetime: Lifetime.SCOPED, ...opts },
+    lifetime: Lifetime.SCOPED,
+    ...opts,
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,16 @@
+import { Resolver } from './resolvers'
+
+export interface ResolverInternal<T> extends Resolver<T> {
+  /**
+   * True if this resolver is a value resolver. Used to implicit set the lifetime of a value
+   * resolver to either {@link Lifetime.SCOPED} or {@link Lifetime.SINGLETON} depending on whether
+   * this value is registered to a root or a scope container.
+   */
+  isValue?: boolean
+
+  /**
+   * True if this resolver should be excluded from lifetime leak checking. Used to exclude alias
+   * resolvers since any lifetime issues will be caught in the resolution of the alias target.
+   */
+  isLeakSafe?: boolean
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,0 @@
-import { LifetimeType } from './lifetime'
-
-export type ResolutionStack = Array<{
-  name: string | symbol
-  lifetime: LifetimeType
-}>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,20 +1,6 @@
 import { LifetimeType } from './lifetime'
-import { Resolver } from './resolvers'
 
-export interface ResolverInternal<T> extends Resolver<T> {
-  /**
-   * True if this resolver is a value resolver. Used to implicit set the lifetime of a value
-   * resolver to either {@link Lifetime.SCOPED} or {@link Lifetime.SINGLETON} depending on whether
-   * this value is registered to a root or a scope container.
-   */
-  isValue?: boolean
-
-  /**
-   * True if this resolver should be excluded from lifetime leak checking. Used to exclude alias
-   * resolvers since any lifetime issues will be caught in the resolution of the alias target.
-   */
-  isLeakSafe?: boolean
-}
-
-export interface ResolutionStack
-  extends Array<{ name: string | symbol; lifetime: LifetimeType }> {}
+export type ResolutionStack = Array<{
+  name: string | symbol
+  lifetime: LifetimeType
+}>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import { LifetimeType } from './lifetime'
 import { Resolver } from './resolvers'
 
 export interface ResolverInternal<T> extends Resolver<T> {
@@ -14,3 +15,6 @@ export interface ResolverInternal<T> extends Resolver<T> {
    */
   isLeakSafe?: boolean
 }
+
+export interface ResolutionStack
+  extends Array<{ name: string | symbol; lifetime: LifetimeType }> {}


### PR DESCRIPTION
Adds new container option `errorOnShorterLivedDependencies` which enables detection and errors on cases where a longer-lived module resolves a shorter-lived dependency, which is then preserved inside the longer-lived module even after its own lifetime and cached resolution expires.

Fixes #348

NOTE: this changes the interface of `ResolutionStack` which was technically exported but should never be needed by client code. Does this constitute a breaking change for versioning purposes?