### PR TITLE
Add awilix-vite in ecosystem section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1410,6 +1410,7 @@ because they depend on Node-specific packages.
 - [`awilix-koa`](https://github.com/jeffijoe/awilix-koa): Bindings for the Koa HTTP library.
 - [`awilix-router-core`](https://github.com/jeffijoe/awilix-router-core): Library for building HTTP bindings for Awilix with routing.
 - [`fastify-awilix`](https://github.com/fastify/fastify-awilix): Bindings for the Fastify framework.
+- [`awilix-vite`](https://github.com/kvist-no/awilix-vite): Use Awilix in Vite projects.
 
 # Contributing
 


### PR DESCRIPTION
package has been published: https://www.npmjs.com/package/awilix-vite

Closes #363 