### PR TITLE
Properly strip Node-specific stuff from browser build

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -80,9 +80,9 @@ export default [
         "import { camelCase } from 'camel-case'":
           'const camelCase = null as any',
         [`export {
-  GlobWithOptions,
-  ListModulesOptions,
-  ModuleDescriptor,
+  type GlobWithOptions,
+  type ListModulesOptions,
+  type ModuleDescriptor,
   listModules,
 } from './list-modules'`]: comment,
         "import * as util from 'util'": '',


### PR DESCRIPTION
This PR fixes the browser build. I had added `type` prefixes to the `list-modules` export but forgot to update the `replace` section in the Rollup config.